### PR TITLE
feat: :sparkles: adds trailing arguments to cli

### DIFF
--- a/.github/workflows/build-status.yaml
+++ b/.github/workflows/build-status.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: backpackapp/build:v0.29.0
     steps:
       - name: Checkout repository

--- a/changelog.md
+++ b/changelog.md
@@ -11,32 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Antegen CLI for managing thread and network program accounts
 - Geyser plugin for indexing Solana transactions
 
-## 1.0.2 (2024-12-24)
-
-## 1.0.1 (2024-12-24)
-
-## 1.0.0 (2024-12-25)
-
-<csr-id-95fb867032ed6053c8caa9b892b83bd79d5d4014/>
-<csr-id-50a1668183d52b56690922f6c6cf34e0cd25b63d/>
-<csr-id-a5f61863223d8aff076ce73c147a41a107a9a4c1/>
-
-### Refactor
-
- - <csr-id-95fb867032ed6053c8caa9b892b83bd79d5d4014/> :recycle: updated to use carge `smart-release`
-
-### Chore
-
- - <csr-id-e3b8f4e49fd7cce1f222aba0baea5ea4534ad346/> :tada: v1.0.0
-
-### Chore
-
- - <csr-id-a5f61863223d8aff076ce73c147a41a107a9a4c1/> :tada: v1.0.0
-
-### Chore
-
- - <csr-id-50a1668183d52b56690922f6c6cf34e0cd25b63d/> :tada: v1.0.0
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
@@ -44,14 +18,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - 1 commit contributed to the release.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
-
-### Commit Details
-
-<csr-read-only-do-not-edit/>
-
-<details><summary>view details</summary>
-
- * **Uncategorized**
-    - :tada: v1.0.0 ([`e3b8f4e`](https://github.com/wuwei-labs/antegen/commit/e3b8f4e49fd7cce1f222aba0baea5ea4534ad346))
-</details>
-

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -56,6 +56,7 @@ pub enum CliCommand {
         solana_archive: Option<String>,
         antegen_archive: Option<String>,
         dev: bool,
+        trailing_args: Vec<String>,
     },
 
     // Pool commands
@@ -382,6 +383,13 @@ pub fn app() -> Command {
                         .action(ArgAction::SetTrue)
                         .default_value("false")
                         .help("Use development versions of antegen programs")
+                )
+                .arg(
+                    Arg::new("test_validator_args")
+                        .num_args(0..)
+                        .allow_hyphen_values(true)
+                        .trailing_var_arg(true)
+                        .help("Arguments to pass to solana-test-validator")
                 )
         )
         .subcommand(

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -147,7 +147,7 @@ impl CliConfig {
 
     pub fn antegen_release_url(tag: &str) -> String {
         format!(
-            "{}/{}/{}",
+            "{}/v{}/{}",
             ANTEGEN_RELEASE_URL,
             tag,
             &Self::antegen_release_archive()

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -86,6 +86,10 @@ fn parse_bpf_command(matches: &ArgMatches) -> Result<CliCommand, CliError> {
         solana_archive: parse_string("solana_archive", matches).ok(),
         antegen_archive: parse_string("antegen_archive", matches).ok(),
         dev: matches.get_flag("dev"),
+        trailing_args: matches.get_many::<String>("test_validator_args")
+            .unwrap_or_default()
+            .map(|s| s.to_string())
+            .collect(),
     })
 }
 

--- a/cli/src/processor/mod.rs
+++ b/cli/src/processor/mod.rs
@@ -79,6 +79,7 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
             solana_archive,
             antegen_archive,
             dev,
+            trailing_args,
         } => localnet::start(
             &mut config,
             &client,
@@ -89,6 +90,7 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
             solana_archive,
             antegen_archive,
             dev,
+            trailing_args
         ),
         CliCommand::PoolGet { id } => pool::get(&client, id),
         CliCommand::PoolList {} => pool::list(&client),


### PR DESCRIPTION
### TL;DR
Added support for passing custom arguments to solana-test-validator in the localnet command and updated the release URL format.

### What changed?
- Added ability to pass trailing arguments to solana-test-validator through the localnet command
- Updated the antegen release URL format to include 'v' prefix
- Added help command support for test-validator arguments
- Changed `-r` flag to `--reset` for test-validator
- Updated GitHub Actions runner to ubuntu-24.04
- Cleaned up changelog entries

### How to test?
1. Run `antegen localnet start --help` to see new test-validator argument options
2. Try starting localnet with custom arguments:
```bash
antegen localnet start -- --limit-ledger-size 50000000 --rpc-port 8899
```
3. Verify that release downloads work correctly with the updated URL format

### Why make this change?
To provide users with more flexibility in configuring their local test validator settings and ensure compatibility with newer infrastructure. This allows for better customization of local development environments and testing scenarios.