### PR TITLE
feat: :sparkles: updated program IDs and README.md

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -8,16 +8,16 @@ members = [
 ]
 
 [programs.localnet]
-antegen_network_program = "F8dKseqmBoAkHx3c58Lmb9TgJv5qeTf3BbtZZSEzYvUa"
-antegen_thread_program = "CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh"
+antegen_network_program = "AgNet6qmh75bjFULcS9RQijUoWwkCtSiSwXM1K3Ujn6Z"
+antegen_thread_program = "AgThdyi1P5RkVeZD2rQahTvs8HePJoGFFxKtvok5s2J1"
 
 [programs.testnet]
-antegen_network_program = "F8dKseqmBoAkHx3c58Lmb9TgJv5qeTf3BbtZZSEzYvUa"
-antegen_thread_program = "CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh"
+antegen_network_program = "AgNet6qmh75bjFULcS9RQijUoWwkCtSiSwXM1K3Ujn6Z"
+antegen_thread_program = "AgThdyi1P5RkVeZD2rQahTvs8HePJoGFFxKtvok5s2J1"
 
 [programs.mainnet]
-antegen_network_program = "F8dKseqmBoAkHx3c58Lmb9TgJv5qeTf3BbtZZSEzYvUa"
-antegen_thread_program = "CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh"
+antegen_network_program = "AgNet6qmh75bjFULcS9RQijUoWwkCtSiSwXM1K3Ujn6Z"
+antegen_thread_program = "AgThdyi1P5RkVeZD2rQahTvs8HePJoGFFxKtvok5s2J1"
 
 [registry]
 url = "https://api.apr.dev"

--- a/README.md
+++ b/README.md
@@ -2,51 +2,67 @@
   <h1>Antegen</h1>
 
   <p>
-    <strong>Solana automation engine</strong>
+    <strong>🦠 Solana automation engine</strong>
   </p>
 
   <p>
-    <a href="https://github.com/wuwei-labs/antegen/actions/workflows/build-status.yaml"><img alt="build status" src="https://github.com/wuwei-labs/antegen/actions/workflows/build-status.yaml/badge.svg?branch=main"/></a>
-    <a href="https://discord.com/channels/889725689543143425"><img alt="Discord Chat" src="https://img.shields.io/discord/889725689543143425?color=blueviolet" /></a>
+    <a href="https://github.com/wuwei-labs/antegen/actions/workflows/build-status.yaml"><img alt="build status" src="https://github.com/wuwei-labs/antegen/actions/workflows/build-status.yaml/badge.svg"/></a>
+    <a href="https://discord.com/channels/1328480150676836462"><img alt="Discord Chat" src="https://img.shields.io/discord/1328480150676836462?color=blueviolet" /></a>
     <a href="https://www.gnu.org/licenses/agpl-3.0.en.html"><img alt="License" src="https://img.shields.io/github/license/wuwei-labs/antegen?color=turquoise" /></a>
   </p>
-
-  <h4>
-    <a href="https://antegen.xyz/">Home</a>
-    <span> | </span>
-    <a href="https://docs.antegen.xyz">Docs</a>
-    <span> | </span>
-    <a href="https://twitter.com/antegen_xyz">Twitter</a>
-  </h4>  
 </div>
+
+# Background
+
+---
+
+## Why was this fork created?
+
+Antegen is a **hard** fork from [Clockwork](https://github.com/clockwork-xyz/clockwork) at commit [44d2038](https://github.com/clockwork-xyz/clockwork/commit/44d2038931da60ba3e192a833096fabee0422d44). This was done to continue the development of the protocol in an Open Source environment. The rebranding from Clockwork to Antegen became necessary due to limitations in accessing and updating the crates.io packages and on-chain programs.
+
+## Fork Details
+
+Antegen maintains the core protocol design from Clockwork while modernizing the codebase for compatibility with the latest Solana ecosystem dependencies. This includes support for:
+
+- Anchor 30.1 and above
+- Solana 2.1.6 (Agave) and above
+- Latest ecosystem dependencies and standards
+- Modern development tooling
+
+This open-source development path enables:
+
+- Community-driven improvements
+- Rapid security patches
+- Continuous dependency updates
+- Enhanced protocol stability
+
+## Opinionated Changes
+
+- Removed Clockwork ThreadV1 program
+- Removed Clockwork Webhook program
+- Updated Clockwork ThreadV2 to Antegen ThreadV1
+
+## Alternatives
+
+There's been work on a truly open source version of Clockwork via the [Open Clockwork](https://github.com/open-clockwork/clockwork) project. Which appears to take the approach of carrying the torch from where the original project left off ensure backwards compatibility.
+
+> [!NOTE]
+> Antegen is now under active development as its own project. While it shares historical roots with Clockwork, all interfaces and implementations are subject to change as the project evolves to meet its unique objectives.
 
 # Deployments
 
 | Program | Address| Devnet | Mainnet |
 | ------- | ------ | ------ | ------- |
-| Network | `F8dKseqmBoAkHx3c58Lmb9TgJv5qeTf3BbtZZSEzYvUa` | [v1.0.0](https://explorer.solana.com/address/F8dKseqmBoAkHx3c58Lmb9TgJv5qeTf3BbtZZSEzYvUa) | [v1.0.0](https://explorer.solana.com/address/F8dKseqmBoAkHx3c58Lmb9TgJv5qeTf3BbtZZSEzYvUa) |
-| Thread v1 | `CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh` | [v1.0.0](https://explorer.solana.com/address/CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh?cluster=devnet) | [v1.0.0](https://explorer.solana.com/address/CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh) |
+| Network | `AgNet6qmh75bjFULcS9RQijUoWwkCtSiSwXM1K3Ujn6Z` |  |  |
+| Thread v1 | `AgThdyi1P5RkVeZD2rQahTvs8HePJoGFFxKtvok5s2J1` |  |  |
 
 # SDKs
 
 | Language | Description  | Lib  | Examples |
 | ----------- | -------- | ---- | -------- |
-| Anchor |  Anchor bindings for Solana programs.  | [crates.io](https://crates.io/crates/antegen-sdk) | [See Example Repo](https://github.com/wuwei-labs/examples)
-| Rust | Rust bindings for clients.  | [crates.io](https://crates.io/crates/antegen-client) | [See Example Repo](https://github.com/wuwei-labs/examples)
-| Typescript | Typescript bindings for clients and frontends.  | [npm](https://www.npmjs.com/package/@wuwei-labs/sdk) | [Explorer](https://github.com/wuwei-labs/explorer)
-
-# Notes
-
-- Antegen is under active development. All interfaces and implementations are subject to change. 
-- Official program deployments to Solana mainnet are secured by a 2-of-2 [multisig](https://v3.squads.so/info/7gqj7UgvKgHihyPsXALW8QKJ3gUTEaLeBYwWbAtZhoCq) and managed by the core team of software maintainers. 
-- To deploy a worker node on mainnet or devnet, please [install](#deploying-a-worker) the Antegen geyser plugin on your Solana validator or RPC node and request an earlybird token delegation in the workernet channel [on Discord](https://discord.gg/mwmFtU5BtA).
-- Occasionally, a new software release may change the state schema and require users to migrate to a new program. These releases will be marked by a new major version upgrade (e.g. `v2.x`, `v3.x`, etc.). 
-- The smart-contracts in this repository are automatically scanned by [Sec3's](https://www.sec3.dev/) auto-auditing software and are currently being reviewed by the team at [Ottersec](https://osec.io/). Their audit report is in progress and will be published soon. 
-
-# Getting Started
-
-- ["I am a developer, and I want to build a program on localnet"](#local-development)
-- ["I am a node operator, and I want to deploy a Antegen worker"](#deploying-a-worker)
+| Anchor |  Anchor bindings for Solana programs.  | [crates.io](https://crates.io/crates/antegen-sdk) |  |
+| Rust | Rust bindings for clients.  | [crates.io](https://crates.io/crates/antegen-client) |  |
+| Typescript | Typescript bindings for clients and frontends.  |  |  |
 
 # Local Development
 
@@ -102,36 +118,4 @@ antegen localnet --dev
 
 ```sh
 solana logs --url localhost
-```
-
-# Guides & Examples
-
-- If you are looking for walkthough, take a look at the docs: https://docs.antegen.xyz/developers/guides.
-- If you have a certain use case you would like to discuss, we are happy to [help](https://discord.com/channels/889725689543143425/1029516796304306247).
-
----
-
-# Deploying a worker
-
-> If you just want to test your smart contracts on localnet, check the previous section.
-
-If you are a node operator looking to deploy the antegen plugin, please talk to us for a smooth onboarding. Here's a one pager on how to be part of the automation network: https://docs.antegen.xyz/workernet/deploying-a-worker.
-
-## Common Errors
-
-Please refer to the [FAQ](https://docs.antegen.xyz/developers/faq).
-
-## Questions
-
-Come build with us and ask questions on [Discord](https://discord.gg/epHsTsnUre)!
-
-## Contributing
-
-```sh
-cargo install smart-release
-```
-
-> `--no-publish` so that the Github action `release.yml` can publish it to crates.io
-```sh
-cargo smart-release --execute --no-publish --update-crates-index
 ```

--- a/programs/network/src/lib.rs
+++ b/programs/network/src/lib.rs
@@ -15,7 +15,7 @@ use instructions::*;
 use jobs::*;
 use state::*;
 
-declare_id!("F8dKseqmBoAkHx3c58Lmb9TgJv5qeTf3BbtZZSEzYvUa");
+declare_id!("AgNet6qmh75bjFULcS9RQijUoWwkCtSiSwXM1K3Ujn6Z");
 
 #[program]
 pub mod network_program {

--- a/programs/thread/src/lib.rs
+++ b/programs/thread/src/lib.rs
@@ -16,7 +16,7 @@ use antegen_utils::{
 use instructions::*;
 use state::*;
 
-declare_id!("CLoCKyJ6DXBJqqu2VWx9RLbgnwwR6BMHHuyasVmfMzBh");
+declare_id!("AgThdyi1P5RkVeZD2rQahTvs8HePJoGFFxKtvok5s2J1");
 
 #[program]
 pub mod thread_program {


### PR DESCRIPTION
### TL;DR
Updated program IDs and documentation to establish Antegen as a hard fork from Clockwork

### What changed?
- Updated program IDs for both network and thread programs across all environments
- Revised README to explain Antegen's relationship to Clockwork
- Added detailed background information about the fork's purpose and objectives
- Removed outdated deployment information and simplified SDK documentation
- Updated Discord and social links

### How to test?
1. Verify new program IDs in Anchor.toml match the declared IDs in the programs:
   - Network Program: `AgNet6qmh75bjFULcS9RQijUoWwkCtSiSwXM1K3Ujn6Z`
   - Thread Program: `AgThdyi1P5RkVeZD2rQahTvs8HePJoGFFxKtvok5s2J1`
2. Follow local development setup instructions in README
3. Validate all documentation links are functional

### Why make this change?
This change establishes Antegen as its own entity while maintaining transparency about its origins. The new program IDs are necessary since we can't use Clockwork's original addresses, and the documentation updates help users understand the relationship between the projects and Antegen's future direction.