### PR TITLE
chore: bump solana / cleanup / build-script

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -146,7 +146,7 @@ jobs:
           fi
 
           mkdir -p staging/bin
-          cargo build --workspace --release --target ${{ matrix.target }}
+          cargo build --workspace --release --target ${{ matrix.target }} --features mainnet
 
           if [[ "${{ matrix.target }}" == *"darwin"* ]]; then
             install -m 644 target/${{ matrix.target }}/release/libantegen_plugin.dylib staging/lib/libantegen_plugin.so

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,13 @@
 .DS_Store
 target
 **/*.rs.bk
+.idea/
 
 # Antegen
 bin/
 lib/
+dist/
+keys/
 .env
 
 # Docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "agave-geyser-plugin-interface"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8218413b2a1c75e8b08d851bfad6daed7e1188607ed92a7d6474591815bc07"
+checksum = "5beb5f9555d007439d578562cce2466ba85ef35e9046dbb6651526ec57a9bca4"
 dependencies = [
  "log 0.4.25",
  "solana-sdk",
@@ -4133,9 +4133,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2af97266ee346ef1cd1649ba462d08bd3d254e50c06c45d3e70a21871a1da6a"
+checksum = "e2197f7b15bc6041fa833974025a6006a111977cd4fd35848b743757c1a409f5"
 dependencies = [
  "bincode",
  "serde",
@@ -4147,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717a67d421f9ba91a7b845af1d5b0039fcb44b86f4b294b28ae447a0f2bf48c8"
+checksum = "fd87b663fb20629017104e7428894dbd020e362a51a117cc5edf5e46a81f7f40"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -4173,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42008241f82751639daee861f1ecaf9c3342d3aa6ce96c063290379a5f9f7c0"
+checksum = "508a03567b2b5421f9e0f01518f77eb1d0131d1c48f5f22223fe626d6902b622"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-info"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed2417317f26f0941dd8e552ac1f9768eb2aa3b7f16ec992a6833f058295bea"
+checksum = "1a67b02d022266e0979a3033f58f83c6e4d45f7e7cc85e6beeaf90b32ef5ede8"
 dependencies = [
  "bincode",
  "serde",
@@ -4202,18 +4202,18 @@ dependencies = [
 
 [[package]]
 name = "solana-atomic-u64"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0cd0453d46a62ed36ce234be9153a3c4d433711f1cec6943345d1637d6a0908"
+checksum = "2453e9e0f5e948d83d1ea5ceef6a0488b39cb57f21e19d73d5dc57f27464ec8d"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "solana-bincode"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97957d987dc85bbfa90cb7e919ee0b071206affc0209e7221d7ea4844e7be31"
+checksum = "b235339197024a4f5c80b2ab5961f616c3ee2aa4542af082a0cc9c84c82b3c09"
 dependencies = [
  "bincode",
  "serde",
@@ -4222,9 +4222,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bn254"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957ce0d8b021f78f7b3c99d82b21a8dae617cf016377647c4d43a6e3141e8f2f"
+checksum = "6f1b3e79f6ad47ffeb75be02d69828c00926af536083dadc6db8282ef1f0774e"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4237,9 +4237,9 @@ dependencies = [
 
 [[package]]
 name = "solana-borsh"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99affe31b10c1cd4a6438d307b92c1b17c89c974aebf2c2aa15cd790d0ba672b"
+checksum = "3950d83165c85ac9cb92be986a76c7a543c5c14c1e98982d6dfad3d98e6b2353"
 dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.5",
@@ -4247,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7cfc66807d0aee9130a906d73d0b7d59754c0edcf1f1a1486eb334abb56835"
+checksum = "54acf877b1e3ce369ebede3c6c4f87e966b320ddc62e9097b9864a7a16b342b7"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -4265,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771b25c9091dddfa3cb7cb0cce62eb4b24840db61c29ee6c3541f1519e1c7953"
+checksum = "1425c1a6506f936bd52fe22308e1a87cf4f9b8ef84042bf1760c5ffa6a37df4b"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4281,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433292dc183886b1f36ee87e971477556226df2f566fc5a19585a0d740aa8b0"
+checksum = "ffc03746e1f603959963e91da0476d13a93235eb201236e2172e68fc680c03f9"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4313,9 +4313,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clock"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97864f28abd43d03e7ca7242059e340bb6e637e0ce99fd66f6420c43fa359898"
+checksum = "4bfdce9a9f46965ffb6e1e7cc0e52efeb834c89dc67d7399770a9d4447498fdb"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4325,18 +4325,18 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f92a2ba8c5ed92fc805f8a92a3bfbbaca05da80d87f180aea4e9f28b9e0fa22"
+checksum = "6989b3fa34b7190243346bee5c4c208b7d24da189c6c3cbd329227d5ab0d6b8b"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a78fbed4792e4cd029a0dd95d14ec42ea602fd7247b40e8fbc4c96b3404da1"
+checksum = "26640009743713f9a5dfa195e511cc817aa5d793e0068415cab80dc03474bca0"
 dependencies = [
  "bincode",
  "chrono",
@@ -4350,9 +4350,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aa1f4cb4c3829357189e6a88624205016b0710f11509f84f772c87c4887159"
+checksum = "925c4c2ab4ff3ae185cc5d52eb1478aed91c052df0c307c9bb1c7f5b595b6b26"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4371,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cpi"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54c3b096dc77222b9c19ffe9cf6c1c32bd1e9882ceb955d213be4315bbe3b95"
+checksum = "dd452db5b927c0abbbd47ccc9f233a480754ecc7d07a9c5826c4d1f09168b6e1"
 dependencies = [
  "solana-account-info",
  "solana-define-syscall",
@@ -4394,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2ed697e82c44b0833550501e3fab428c07cc2865c788307fad4c98a64d27d0"
+checksum = "af29b27893aa7bc5082f30ef653c9319b36ac2b2d0f5c44688a5e80c42fcd892"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -4407,24 +4407,24 @@ dependencies = [
 
 [[package]]
 name = "solana-decode-error"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c92852914fe0cfec234576a30b1de4b11516dd729226d5de04e4c67d80447a7"
+checksum = "4a1d529c1056b4d461609224fa1bf2a6584eafddf435c6394697b0f5de8c812c"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "solana-define-syscall"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44015e77f6f321bf526f7d026b08d8f34b57b1ea6e46038fd13e59f43a53a475"
+checksum = "3c012a5bdc1122a74880faf6684b32286a9fae0086ff0a3efb16d7f3681fca90"
 
 [[package]]
 name = "solana-derivation-path"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cd4b95383d8926cc22d4a33417aa2e38897475f259cff4eb319c8cf0f7ac02"
+checksum = "0803b6ea9c3b9f3c3f540535d6a9d32e6fa6a2ae368a3a93eb4a61c3a216c65d"
 dependencies = [
  "derivation-path",
  "qstring",
@@ -4433,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3409f250234ec4bbd999de3eac727ca21dfbfd39a831906f6ec112a66d2e1a2"
+checksum = "dc5bd1733a0099c803b5e63be64ef6be1041b52010481f12a7d81124615e030d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4445,9 +4445,9 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-set"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ddda14ac5f2da82da4df043eabca2f2c00ac0d59f10295b8c8c3404fcc5f67"
+checksum = "4d7034fc05eae9180a5ae63f87a2e9985f8e0ae3c1269973c523d1028a78ffe3"
 dependencies = [
  "lazy_static",
  "solana-clock",
@@ -4459,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8db8c4be5e012215ed1e3394cd3c188e217dd4f0c821045e5d2c1262aac8b4e"
+checksum = "6337eace41da19d476fe80c86a8a2f5cad76125c2aa672788ec7f2814a62478a"
 dependencies = [
  "log 0.4.25",
  "serde",
@@ -4470,9 +4470,9 @@ dependencies = [
 
 [[package]]
 name = "solana-hash"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25925816be2f57992c4c5af7dff31713bc95696c2fbc4bca911e290ba2f330"
+checksum = "36647a50db4d401721e55d6bc1d259a8cea7bc333ab41c6358d2f5b344a1ab4e"
 dependencies = [
  "borsh 1.5.5",
  "bs58 0.5.1",
@@ -4488,9 +4488,9 @@ dependencies = [
 
 [[package]]
 name = "solana-inflation"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91a53086a0f0cc093ffce9e5be4399785f05a0d49f0ff2cd6d5f3f4d593e2e9"
+checksum = "4c2ea0e34ad32c6a1a026f284716c9c21cd1c3dc496a595640f76ef4bf364f1d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4498,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4fa02c553c48a6e189960b5bd3aa854b29c888bd5db4c1ad4bb6a0cc068c78"
+checksum = "4ad76e0824d7e4fdd313a53080320e653f453f4f76737fe1b92c9c66db246ee7"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -4508,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab8c46b6f76857222ee1adeb7031b8eb0eb5134920614e9fd1bd710052b96a9"
+checksum = "d7a99a1276782510f3f9d8dac058b9fccadfc62ff4fd5b7c6d462dbf46632181"
 dependencies = [
  "bincode",
  "borsh 1.5.5",
@@ -4526,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633f272467f3e1a28dfcfb1a7df55129752524a18938a84fd67086e205f0bd88"
+checksum = "55a1090667f03719f886b86f90a333b0741df8692fb7076529ae2ab066e2f4b4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4538,18 +4538,18 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034627f9849eeafcbfa24f0e4ad0da50eb68422ceab5c605b7d87755af77b201"
+checksum = "606f71865c0889b7dbdccd2a75586ec028461d648901708f2bb5f5c6bee5693d"
 dependencies = [
  "log 0.4.25",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef1468f78c6f891ac2e3ce6e81bd0c47cff18598fb87618ab2e3d39da4bb69f"
+checksum = "2a04631dad2f0969dfa5e79e6ba2e693ed7264a013935f2c264b3352e7a09613"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4558,15 +4558,15 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fa953c2b49a131492b5927e714ab60b7b927610c7ed3355b9ad28909622b5e"
+checksum = "04cd58f210630986a5c3f0344da347bb75fc2a90f2fe287438a81cd2c6ffcc8b"
 
 [[package]]
 name = "solana-metrics"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce8eeecdde1cfed801d0d8683856e0e0cc731119894a7ae77a966915cf84964"
+checksum = "58eec7006fe02032aa28f0ff49f3b378d64f16597d725af2887febc0f4ba3e9c"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4579,24 +4579,24 @@ dependencies = [
 
 [[package]]
 name = "solana-msg"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80dde3316c6ee6e8d57bf105139ec93f8c32a42fe3ec42a3cda2ca9efb72c0e6"
+checksum = "59b84934c69aa9799b661f87aa1c47f8d358c3912fe5843571a5d047a222a0e6"
 dependencies = [
  "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-native-token"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0721f46122a2f1837f571d5a6c1478c962ebefd6d65d02694b3a267b58dbf2"
+checksum = "1e628d59c4f2ca1e5765a99bf7a1f5fb87e6c834ad2992d84024141be32f21c8"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404052690fb907fdda741f662610ac26c785cdff2154204a109b14d3e2f4b6bd"
+checksum = "23805df410fef2238a6710205c5b4de92f4f46cabd2555538795404ba09b0b7a"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4613,9 +4613,9 @@ dependencies = [
 
 [[package]]
 name = "solana-packet"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fcc5cf0ef0ac6a62dd09fae772672c2d6865ee1d1ba5fbfbcc94b2c37b2be8"
+checksum = "cf27339d38ffc14b456e93f59a998cdd79079bec6776bef364a8aa1ee2ceed69"
 dependencies = [
  "bincode",
  "bitflags 2.8.0",
@@ -4627,9 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed01176ddc5ade70e0782b3eeea0f5e98f183dc5b225e4e051834e63a288c0"
+checksum = "448f819049c558369f24607de2e8240476cfc7549be51e98a5c4c62c38032780"
 dependencies = [
  "ahash",
  "bincode",
@@ -4654,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "solana-precompile-error"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54310052930124b78392b03d802aa465afe6fded96d97f2e6ca6b1dead85d8d9"
+checksum = "c439844f1c18ec47ab13b5ed229cb0d9eacd75a7fafb8f150004b9a5ee11445e"
 dependencies = [
  "num-traits",
  "solana-decode-error",
@@ -4664,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12511916a9658664921ca12dd6214910de655ac9955159c1e9871bd516936cac"
+checksum = "5b23f3bdb67fec4edc60ce12b5583c5425aab96dbb029636d400cd3f36242412"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4737,9 +4737,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3422fa98d2ac5b20df9c9feb9f638e1170341b3c4259c26cd91a6a7098f6830"
+checksum = "bc27bbb6ff7f346b93173cacd14a44873e24a1702a07ebbe4a9295bf53eed3cb"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -4749,9 +4749,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-error"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2ea6d8e88767586e6d547e5afb00cda08cee79c986443b2d47236aac50a755"
+checksum = "f5f48931e21e648410a17a1a42b3ace669e1b6c55516357f40ac6b91d4f81ef1"
 dependencies = [
  "borsh 1.5.5",
  "num-traits",
@@ -4765,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-memory"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716e1c9cbd3c5e9d9147ffb7e74815cfb34ff7a3196127da64aa8d1866beab52"
+checksum = "783ed2a707f3e875480ab0beda89951e8807cb0f76e30c19f82dd305b9169ab3"
 dependencies = [
  "num-traits",
  "solana-define-syscall",
@@ -4775,24 +4775,24 @@ dependencies = [
 
 [[package]]
 name = "solana-program-option"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c8ffad2c86e5de375ae5f0a46f64eb5897a63c514e958e908c1a98059c57d4"
+checksum = "af0be45a0148239936e931a0ae95052a66e0b8f257205c9304af39bf2211a8de"
 
 [[package]]
 name = "solana-program-pack"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c185f9170ac85a93d5caaaaf5fe7bf0d49febdb329506bd7ea13716e4eb0189"
+checksum = "02d992004feb5e4b8bec891470f38b029fa8a304ce762ca835ffcc67cc6bf385"
 dependencies = [
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cf60b4b2d8d70b082d03973b8e646ca1c65351eb12ab33427c2df40cd178cf"
+checksum = "09ed4dedcffb93dcf823dd0db043bb142ecc839d354c15347e75a370585b7c71"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4820,9 +4820,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb80787769457f022a39a55cf439d1996aeecc2364c99483c97318d80f15436"
+checksum = "2d4cb0f3b71f466fe8e11bef05dc562060b5c8f526e969ecd150ce5bedc6e3eb"
 dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.5",
@@ -4847,9 +4847,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d5e1c9d387f98d46a675f418f29b73a5555ceddc2800faa38ce2f87feba3b2"
+checksum = "52a1c92ef08fa6754295c6e0b358e3255937dfb72c9c5a96bc04e9ec07f795dc"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4872,9 +4872,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8579061d3a98f3b6b45f675da8b4fdcf435109ef6c6269b95ee0f33a52a5ac4d"
+checksum = "0f4780e9e7c5e14566fee78ba7f8844c4d8ca2175572d92dcf8444fc845d144b"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -4898,9 +4898,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cac659c899faffd06d57164fbdf142d7395e147843031ecd0ec48ee11be3b06"
+checksum = "3ef222b9c11ee0f451505c073774e279f484921b1af53201dfc7e49bd4106259"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4908,9 +4908,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531d38fa26935c234d9b111362377a886f3662dd5c76477fa05c48144625f1e4"
+checksum = "fb8d37eae21437bf3e06f5430eba5219a182860679773e2751b5d49bb15c1714"
 dependencies = [
  "console",
  "dialoguer",
@@ -4928,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rent"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b4cd58602eb0c2250cd83a8cc8287ca6271b99af95d2a33250e6592c04e286"
+checksum = "4cb62c792559733d5f5d2ee42383e8d3b336e5168472ebdaaf157fd6f1949973"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4940,9 +4940,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3102d6dfbadc375f22f7413effafcf2d7d2cb3e8cdf64f366dacd7c5cbae27cb"
+checksum = "e7b40d68b77b47a7786965eca51207dd19cb68bb518da7476e84cc4f87f5c334"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4967,9 +4967,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9ca3a7af9655a401c285f953c22525cad2698913ea4fa28cf217965929f80a"
+checksum = "4520467a0bb012c7ecf121eaae0182d4c3c0647844c6bbcbeea87997a9cdc97e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4991,9 +4991,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551090640700bbb5f2b593a1f6146603cab53fc13a94120d28180f9941dc9ab2"
+checksum = "1396307c7e3a72ed8074cb1c31f7f6613d3e71f0f3414911ccbaeea29690158d"
 dependencies = [
  "solana-rpc-client",
  "solana-sdk",
@@ -5002,15 +5002,15 @@ dependencies = [
 
 [[package]]
 name = "solana-sanitize"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c557ff8937946d24c4f188f3029c1fdba4e23a15ed11cc8b31a72017e911d5"
+checksum = "e956e49e563eb8a9aa09425d676180a0a0509038be4457f230bb6e1dfa036053"
 
 [[package]]
 name = "solana-sdk"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d755acdf62b367c1c4ca7ac1069c34a090d281b6425d11dd9410d4a147d99d3"
+checksum = "a2625a64d46eccd46452df612f4266f24d266eb43ccac2a566ec41ee2ec76262"
 dependencies = [
  "bincode",
  "bitflags 2.8.0",
@@ -5072,9 +5072,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9055600bc70a91936458b3a43a4173f8b8cd4ee64a0dc83cbb00737cadc519a5"
+checksum = "6102303ef82f601e178970388256cd2841618d0789246c087c164760bd976b2f"
 dependencies = [
  "bs58 0.5.1",
  "proc-macro2",
@@ -5084,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-recover"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b904576bfc5b72172aed9c133fe54840625ab9d510bd429d453c54bd6e4245c3"
+checksum = "a5658cf3a6792df8bc40da3c6cd8ff2d96ad494f3102a6c70ee41774647b0b0e"
 dependencies = [
  "borsh 1.5.5",
  "libsecp256k1",
@@ -5096,9 +5096,9 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256r1-program"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c1329b7faa66f80bb3dadcece042589d22881120b6c0d0f712f742ad002f26"
+checksum = "3f1acf1413825581b79339a3b8427466f0a3b677c85cafe5d0827a3a6f7a6680"
 dependencies = [
  "bytemuck",
  "openssl",
@@ -5116,18 +5116,18 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-serde-varint"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e741efbc732c2e33fd600d39a5a5e63cbab18fc75fc84a98df68c2aa2b373b64"
+checksum = "591ff7fba3f641998d613f6934bd89222cf45b0393225dc3c4af09b2b8f94d33"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "solana-serialize-utils"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6511f5147f992239415bd4bb297ad593da57b4ab634ed9bc10f81a560bc90"
+checksum = "304f0afa82feddfdab31a97148717bf33a0e1cd67261aa1fce55835eff0a5a90"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -5136,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3456f5d3868b9ae8e7bc53529bbbd8bee48b0d9cf3783f918269e71e4ee5268d"
+checksum = "de0e647536438a92f1b02424d94c703534566aa9b1d8aae87f3b181d2dc5787c"
 dependencies = [
  "sha2 0.10.8",
  "solana-define-syscall",
@@ -5147,18 +5147,18 @@ dependencies = [
 
 [[package]]
 name = "solana-short-vec"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01771c84475e25352169e3fc901cae565f75ff8c9b40a4fa858f776211f20cbc"
+checksum = "8cfbe01016ac7c0ac992fae610f46607b7d8cadba5c526f2b8701123bc28e5ce"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f89b547c800c3541d4d5d71de8c82f37a0050f361626213a425ad4f767da27b"
+checksum = "7a515db8b6bbce5a603e09cda69e459ec8d5964a8711e40689ae596da0d9907a"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -5171,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-hashes"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3012c024a81d591d02a10648d5f4256d6fc3c9d93bc5421cadba224794940f6c"
+checksum = "327614604f49be7b292e4fefeca60da6b16720ef2edf35458b1923f0a34b0e2e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5183,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-history"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a68e2aae8fbcf00adef67eba05c513b0a461b5ed1fd0bd2cb1299a394a650"
+checksum = "bfd9d02ec3cdf702027aaee2faac215aa0d8825f6b399b205236f349bd6c8e79"
 dependencies = [
  "bv",
  "serde",
@@ -5195,9 +5195,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stable-layout"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec316bf731aeb8e9e8a55634efb938eaf5c979d71a9e7d3de54f5848da4994a2"
+checksum = "6ee6374e06b1373c4d526e87f02a5ee165093d341c0c5ab548fc79f6ff18e331"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -5205,9 +5205,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4631cb6e5291e226068e73cf98b4962056eb3c1c32448ce7b8e9f31df522263c"
+checksum = "85090db4563b271711d44275a20d1becb4a92e2fdeb41f5234b45df0321e807d"
 dependencies = [
  "async-channel",
  "bytes",
@@ -5243,18 +5243,18 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar-id"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6ca7b6e6bf9f8c0de74e90546426190385a1c0b8e4d4f1975165f2335f9dc0"
+checksum = "d11cdbc013ed4f65a636762b9a62cb878dd530062804e6a6be0faa76f5902914"
 dependencies = [
  "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-thin-client"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581ee5cfdd3c509dc7d744970e5e978dab475fff68058a1198bdaf95e9240eaa"
+checksum = "791e9df56e5a0bee348868b292f6b187c2392bd8f4227b53afdc5da41bfeb4de"
 dependencies = [
  "bincode",
  "log 0.4.25",
@@ -5267,9 +5267,9 @@ dependencies = [
 
 [[package]]
 name = "solana-timings"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f948e963c99cee7d2a14da5faf864cb4ae298f8cb679fc088ec581d9d76aed"
+checksum = "629d606363f36eed6c79a1a96083050380733e5785ba05e52321ff593e806efe"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -5278,9 +5278,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f832646c0c836f54998c07d34980852837ea30de0f383c8eb0b5ad2a60cc05"
+checksum = "b4b059f1d7251f59aa827e0142ff3a7120e782bc10197f26ec931bcfdecb3b06"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5301,9 +5301,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a6d17d8de8549df56d64b9af314eec3c4b705372790aa8dde7196e1c5f005"
+checksum = "589ed4a290547a8ad581f4ede34cb9c164953203aa23b415c761cfb8b06cac89"
 dependencies = [
  "serde",
  "serde_derive",
@@ -5313,9 +5313,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1906692abc629b5a2a76c76f3006dd4a9e96917000b043fd311d7bfbc24607f2"
+checksum = "73ac92b4805fa6e26b8e6c299152028a62d187b82a38448aba77e32713b0504f"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5329,9 +5329,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadee373e77a84b180d955847e7f013195b43498e1a8c526c27771e8d0140915"
+checksum = "aba18ead34f69642fc0bda6440a79b905feb4f7c22ace8e922e79d44eaa401fa"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5357,9 +5357,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc4018fa5363ccf0932b26821abf47c226f52fb865b2944d1f29db83a11774a"
+checksum = "d699c9fb614eb6c5e85ad5992c7ce13cfa8fcc107e3d44c3767386c1c3d96b96"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5375,9 +5375,9 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9673b27fb01b5479a25bfdd83d5ea1112433c8cf81a0aa8616c829587b285ecd"
+checksum = "21ac99386eaec9b90c55a22dee445d88b04398e31023bd1749dd58dff150385e"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -5385,9 +5385,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a073d7abe99c118378562f2f39037b5f66f926c668cc1162de327b20bbd82c"
+checksum = "8f27b8036385c11703a2caaea746575d938d11c97ef4fa8c1260434ac04b1d2d"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -5400,9 +5400,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce3a7b94b3772a3dc66b28f2b6abc7b4b510dbc36387b618398111acc26ec57"
+checksum = "9659399d0f2cdaa928632f4dbb342c327f4b1cd0d8034c2d4e58272fa2f5dfad"
 dependencies = [
  "semver",
  "serde",
@@ -5414,9 +5414,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1a73fa59c07095599091dd9f026aceb478109d61d41720883a22ead9c18f8e"
+checksum = "3d7917e3041555c37ba15028415ec424ff7833acc4f62941ce077ad5c6661198"
 dependencies = [
  "itertools 0.12.1",
  "log 0.4.25",
@@ -5428,9 +5428,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573944c767e4908d6ba12151029cb9ac33b49e7082991c6d978d3ab83ac68d6b"
+checksum = "3e0a99621fd1c0e49c429de07c0837bf0b00f73ac91d7ed2c3a8fd4cdf884fd8"
 dependencies = [
  "bincode",
  "log 0.4.25",
@@ -5448,9 +5448,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5f33e61ecb86621dd7b47e164ec09021b0c910a79e3a6b17ae763554ad7138"
+checksum = "d07c66d2589fb44e2050be900519070a15dbe8e7793977f586952fe9d1248ae6"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -5480,9 +5480,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.1.11"
+version = "2.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9c007da85c5be2273c96647e4070bf69b2fda7ba43cddf5eab84c14b2fad67"
+checksum = "69b8b882464177ef5621d2b91124d3a0d8f7d6b107eca8a58f76e6c84c642104"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,11 +368,11 @@ dependencies = [
 
 [[package]]
 name = "antegen"
-version = "2.1.0"
+version = "2.1.1"
 
 [[package]]
 name = "antegen-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-network-program"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-plugin"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anchor-lang",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-plugin-utils"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "agave-geyser-plugin-interface",
  "serde",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-sdk"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anchor-lang",
  "antegen-thread-program",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-thread-program"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-utils"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anchor-lang",
  "base64 0.22.1",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cron"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ members = [
     "cli",
     "cron",
     "plugin",
-    "programs/*",
+    "programs/thread",
+    "programs/network",
     "sdk",
     "utils"
 ]
@@ -55,9 +56,7 @@ antegen-network-program = { path = "programs/network", features = ["no-entrypoin
 anchor-lang = { git = "https://github.com/coral-xyz/anchor", rev = "6df05aa5b5d9971041e3d25a246d935252b6e576" }
 anchor-spl = { features = ["mint", "token"], git = "https://github.com/coral-xyz/anchor", rev = "6df05aa5b5d9971041e3d25a246d935252b6e576" }
 
-actix-cors = { version = "0.6.4" }
-actix-web = { version = "4.3.1" }
-agave-geyser-plugin-interface = { version = "=2.1.11" }
+agave-geyser-plugin-interface = { version = "=2.1.13" }
 anyhow = { version = "1.0.94" }
 async_once = { version = "0.2.6" }
 async-trait = { version = "0.1.83" }
@@ -65,7 +64,6 @@ base64 = { version = "0.22.1" }
 bincode = { version = "1.3.3" }
 bs58 = { version = "0.5.1" }
 bugsnag = { version = "0.2.1" }
-byte-unit = { version = "4.0.18" }
 bzip2 = { version = "0.5.0" }
 chrono = { version = "0.4.39", default-features = false, features = ["alloc"] }
 clap = { version = "4.5.23", features = ["derive"] }
@@ -78,23 +76,20 @@ nom = { version = "7.1.3" }
 once_cell = { version = "1.20.2" }
 prost = { version = "0.12.3" }
 pyth-sdk-solana = { version = "0.10" }
-rayon = { version = "1.7.0" }
-regex = { version = "1.7.1" }
 reqwest = { version = "0.11.20", features = ["blocking", "json"] }
 serde = { version = "1.0.216" }
 serde_json = { version = "1.0.133" }
 serde_yaml = { version = "0.9.34" }
 simple-error = { version = "0.3.1" }
-solana-account-decoder = { version = "=2.1.11" }
-solana-clap-utils = { version = "=2.1.11" }
-solana-cli-config = { version = "=2.1.11" }
-solana-client = { version = "=2.1.11" }
-solana-logger = { version = "=2.1.11" }
-solana-program = { version = "=2.1.11" }
-solana-quic-client = { version = "=2.1.11" }
-solana-sdk = { version = "=2.1.11" }
-solana-transaction-status = { version = "=2.1.11" }
-solana-zk-token-sdk = { version = "=2.1.11" }
+solana-account-decoder = { version = "=2.1.13" }
+solana-clap-utils = { version = "=2.1.13" }
+solana-cli-config = { version = "=2.1.13" }
+solana-client = { version = "=2.1.13" }
+solana-logger = { version = "=2.1.13" }
+solana-program = { version = "=2.1.13" }
+solana-quic-client = { version = "=2.1.13" }
+solana-sdk = { version = "=2.1.13" }
+solana-transaction-status = { version = "=2.1.13" }
 spl-associated-token-account = { version = "6.0.0" }
 spl-memo = { version = "6.0.0" }
 spl-token = { version = "7.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Antegen Maintainers <maintainers@antegen.xyz>"]
 repository = "https://github.com/wuwei-labs/antegen"
 homepage = "https://antegen.xyz/"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Antegen is a **hard** fork from [Clockwork](https://github.com/clockwork-xyz/clo
 Antegen maintains the core protocol design from Clockwork while modernizing the codebase for compatibility with the latest Solana ecosystem dependencies. This includes support for:
 
 - Anchor 30.1 and above
-- Solana 2.1.6 (Agave) and above
+- Solana 2.1.13 (Agave) and above
 - Latest ecosystem dependencies and standards
 - Modern development tooling
 
@@ -79,7 +79,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 #### 2. Install Solana CLI
 
 ```sh
-sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.6/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.13/install)"
 ```
 
 #### 3. Install Anchor (avm)

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -163,7 +163,7 @@ impl CliConfig {
         format!(
             "{}/{}/{}",
             SOLANA_RELEASE_BASE_URL,
-            tag,
+            tag.replace("=", ""),
             &Self::solana_release_archive()
         )
     }

--- a/cli/src/processor/mod.rs
+++ b/cli/src/processor/mod.rs
@@ -4,6 +4,7 @@ mod network;
 mod localnet;
 mod pool;
 mod registry;
+// mod snapshot;
 mod thread;
 mod worker;
 

--- a/cli/src/processor/registry.rs
+++ b/cli/src/processor/registry.rs
@@ -40,6 +40,7 @@ pub fn reset(client: &Client) -> Result<(), CliError> {
             payer: admin,
             admin,
             registry,
+            registry_fee: RegistryFee::pubkey(registry),
             snapshot: Snapshot::pubkey(0),
             system_program: system_program::ID,
         }.to_account_metas(Some(false)),

--- a/cli/src/processor/snapshot.rs
+++ b/cli/src/processor/snapshot.rs
@@ -1,45 +1,24 @@
-use antegen_network_program::state::{Registry, Snapshot, SnapshotEntry};
-use solana_sdk::pubkey::Pubkey;
-
+use antegen_network_program::state::{Registry, Snapshot};
 use crate::{client::Client, errors::CliError};
 
-pub fn get(client: &Client, entry_id: Option<u64>) -> Result<(), CliError> {
-    let registry_pubkey = antegen_client::network::objects::Registry::pubkey();
+pub fn get(client: &Client, id: Option<u64>) -> Result<(), CliError> {
+    let registry_pubkey = Registry::pubkey();
     let registry = client
         .get::<Registry>(&registry_pubkey)
         .map_err(|_err| CliError::AccountDataNotParsable(registry_pubkey.to_string()))?;
 
-    let snapshot_pubkey =
-        antegen_client::network::objects::Snapshot::pubkey(registry.snapshot_count - 1);
+    let snapshot_id = match id {
+        Some(i) => i,
+        None => registry.current_epoch
+    };
+
+    let snapshot_pubkey = Snapshot::pubkey(snapshot_id);
     let snapshot = client
         .get::<Snapshot>(&snapshot_pubkey)
         .map_err(|_err| CliError::AccountDataNotParsable(snapshot_pubkey.to_string()))?;
 
     println!("{:#?}", snapshot);
-
-    match entry_id {
-        None => (),
-        Some(entry_id) => {
-            get_snapshot_entry(client, snapshot_pubkey, entry_id).ok();
-        }
-    }
-
     Ok(())
 }
 
-pub fn get_snapshot_entry(
-    client: &Client,
-    snapshot_pubkey: Pubkey,
-    entry_id: u64,
-) -> Result<(), CliError> {
-    let entry_pubkey =
-        antegen_client::network::objects::SnapshotEntry::pubkey(snapshot_pubkey, entry_id);
-
-    let entry = client
-        .get::<SnapshotEntry>(&entry_pubkey)
-        .map_err(|_err| CliError::AccountDataNotParsable(snapshot_pubkey.to_string()))?;
-
-    println!("{:#?}", entry);
-
-    Ok(())
-}
+// delete

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ build:
     anchor build
 
 make:
-    ./scripts/build-all.sh .
+    ./scripts/build-all.sh --release dist/
 
 tarball:
     ./scripts/ci/create-tarball.sh

--- a/programs/network/src/instructions/registry_reset.rs
+++ b/programs/network/src/instructions/registry_reset.rs
@@ -38,6 +38,15 @@ pub struct RegistryReset<'info> {
   )]
   pub snapshot: Account<'info, Snapshot>,
 
+  #[account(
+    init_if_needed,
+    payer = payer,
+    space = 8 + std::mem::size_of::<RegistryFee>(),
+    seeds = [SEED_REGISTRY_FEE, registry.key().as_ref()],
+    bump
+  )]
+  pub registry_fee: Account<'info, RegistryFee>,
+
   #[account(address = system_program::ID)]
   pub system_program: Program<'info, System>,
 }
@@ -45,10 +54,12 @@ pub struct RegistryReset<'info> {
 pub fn handler(ctx: Context<RegistryReset>) -> Result<()> {
   // Get accounts
   let registry = &mut ctx.accounts.registry;
+  let registry_fee = &mut ctx.accounts.registry_fee;
   let snapshot = &mut ctx.accounts.snapshot;
 
   // Reset accounts to their initial state
   registry.reset()?;
+  registry_fee.init(registry.key())?;
   snapshot.init(0)?;
 
   Ok(())

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -a BINS=(
+  antegen
+)
+
+usage() {
+  exitcode=0
+  if [[ -n "$1" ]]; then
+    exitcode=1
+    echo "Error: $*"
+  fi
+  cat <<EOF
+usage: $0 [--release] [--target <target triple>] <install directory>
+EOF
+  exit $exitcode
+}
+
+# Set default target triple from 'cargo -vV'
+defaultTargetTriple=$(cargo -vV | grep 'host:' | cut -d ' ' -f2)
+
+# Set build flags
+installDir=
+buildVariant=debug
+maybeReleaseFlag=
+targetTriple="$defaultTargetTriple"
+while [[ -n $1 ]]; do
+  if [[ ${1:0:1} = - ]]; then
+    case $1 in
+      --release)
+        maybeReleaseFlag=--release
+        buildVariant=release
+        shift
+        ;;
+      --target)
+        targetTriple=$2
+        shift 2
+        ;;
+      *)
+        usage "Unknown option: $1"
+        ;;
+    esac
+  else
+    installDir=$1
+    shift
+  fi
+done
+
+# If target triple is still unset, use default
+if [[ -z "$targetTriple" ]]; then
+  targetTriple="$defaultTargetTriple"
+fi
+
+# Print final configuration
+echo "Build variant: $buildVariant"
+echo "Target triple: $targetTriple"
+echo "Install directory: $installDir"
+echo "Release flag: ${maybeReleaseFlag:---not-set}"
+
+# Check the install directory is provided
+if [[ -z "$installDir" ]]; then
+  usage "Install directory not specified"
+  exit 1
+fi
+
+# Create the install directory
+installDir="$(mkdir -p "$installDir"; cd "$installDir"; pwd)"
+mkdir -p "$installDir/lib"
+mkdir -p "$installDir/bin"
+echo "Install location: $installDir ($buildVariant)"
+cd "$(dirname "$0")"/..
+SECONDS=0
+
+# Build programs
+(
+  set -x
+  source ~/.bash_profile
+  anchor build
+)
+
+# Define lib extension
+case $targetTriple in
+  *darwin*)
+    pluginFilename=libantegen_plugin.dylib
+    ;;
+  *)
+    pluginFilename=libantegen_plugin.so
+    ;;
+esac
+
+# Build the repo
+(
+  set -x
+  cargo build --workspace --locked $maybeReleaseFlag --target "$targetTriple"
+  
+  # Copy binaries
+  case $targetTriple in
+    *darwin*)
+      pluginFilename=libantegen_plugin.dylib
+      cp -fv "target/$targetTriple/$buildVariant/$pluginFilename" "$installDir"/lib
+      mv "$installDir"/lib/libantegen_plugin.dylib "$installDir"/lib/libantegen_plugin.so
+      ;;
+    *)
+      pluginFilename=libantegen_plugin.so
+      cp -fv "target/$targetTriple/$buildVariant/$pluginFilename" "$installDir"/lib
+      ;;
+  esac
+
+  for bin in "${BINS[@]}"; do
+    rm -fv "$installDir/bin/$bin"
+    cp -fv "target/$targetTriple/$buildVariant/$bin" "$installDir/bin"
+  done
+
+  cp -fv "target/deploy/antegen_network_program.so" "$installDir/lib"
+  cp -fv "target/deploy/antegen_thread_program.so" "$installDir/lib"
+)
+
+# Success message
+echo "Done after $SECONDS seconds"
+echo 
+echo "To use these binaries:"
+echo "  export PATH=$installDir/bin:\$PATH"
+


### PR DESCRIPTION
This pull request includes several changes to the `Cargo.toml`, `README.md`, `justfile`, and `scripts/build-all.sh` files to update dependencies, modify build scripts, and improve documentation. The most important changes include updating Solana dependencies, adding new programs, and enhancing the build script.

Dependency Updates:

* Updated Solana dependencies from version `2.1.11` to `2.1.13` in `Cargo.toml`.

Program Additions:

* Added `programs/thread` and `programs/network` to the `members` list in `Cargo.toml`.
* Added `antegen-network-program` with path `programs/network` in `Cargo.toml`.

Documentation Updates:

* Updated Solana version in `README.md` from `2.1.6` to `2.1.13`.
* Updated Solana CLI installation command in `README.md` to use the new version `2.1.13`.

Build Script Enhancements:

* Enhanced `scripts/build-all.sh` to include options for release builds and target triples, and to handle installation directories.
* Modified the `make` target in `justfile` to use the `--release` flag and specify the `dist/` directory.