### PR TITLE
feat: :sparkles: updates thread delete command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -53,7 +53,8 @@ pub enum CliCommand {
         skippable: Option<bool>,
     },
     ThreadDelete {
-        id: String,
+        id: Option<String>,
+        address: Option<Pubkey>,
     },
     ThreadGet {
         id: Option<String>,
@@ -423,11 +424,19 @@ pub fn app() -> Command {
                         .arg(
                             Arg::new("id")
                                 .index(1)
+                                .required(false)
                                 .value_name("ID")
                                 .num_args(1)
-                                .required(false)
-                                .help("The id of the thread to delete"),
-                        ),
+                                .help("The ID of the thread to delete (must have authority)")
+                        )
+                        .arg(
+                            Arg::new("address")
+                                .short('k')
+                                .long("address")
+                                .value_name("ADDRESS")
+                                .num_args(1)
+                                .help("The address of the thread to delete"),
+                        )
                 )
                 .subcommand(
                     Command::new("get")

--- a/cli/src/parser.rs
+++ b/cli/src/parser.rs
@@ -159,7 +159,8 @@ fn parse_thread_command(matches: &ArgMatches) -> Result<CliCommand, CliError> {
             skippable: matches.get_one::<bool>("skippable").copied(),
         }),
         Some(("delete", matches)) => Ok(CliCommand::ThreadDelete {
-            id: parse_string("id", matches)?,
+            id: parse_string("id", matches).ok(),
+            address: parse_pubkey("address", matches).ok(),
         }),
         Some(("get", matches)) => Ok(CliCommand::ThreadGet {
             id: parse_string("id", matches).ok(),

--- a/cli/src/processor/mod.rs
+++ b/cli/src/processor/mod.rs
@@ -86,7 +86,10 @@ pub fn process(matches: &ArgMatches) -> Result<(), CliError> {
             schedule,
             skippable
         } => thread::memo_test(&client, id, schedule, skippable),
-        CliCommand::ThreadDelete { id } => thread::delete(&client, id),
+        CliCommand::ThreadDelete { id, address } => {
+            let pubkey = parse_pubkey_from_id_or_address(client.payer_pubkey(), id, address)?;
+            thread::delete(&client, pubkey)
+        },
         CliCommand::ThreadPause { id } => thread::pause(&client, id),
         CliCommand::ThreadResume { id } => thread::resume(&client, id),
         CliCommand::ThreadReset { id } => thread::reset(&client, id),

--- a/cli/src/processor/thread.rs
+++ b/cli/src/processor/thread.rs
@@ -89,14 +89,13 @@ pub fn memo_test(
     )
 }
 
-pub fn delete(client: &Client, id: String) -> Result<(), CliError> {
-    let thread_pubkey = Thread::pubkey(client.payer_pubkey(), id.into_bytes());
+pub fn delete(client: &Client, address: Pubkey) -> Result<(), CliError> {
     let ix = Instruction {
         program_id: antegen_thread_program::ID,
         accounts: antegen_thread_program::accounts::ThreadDelete {
             authority: client.payer_pubkey(),
             close_to: client.payer_pubkey(),
-            thread: thread_pubkey,
+            thread: address,
         }.to_account_metas(Some(false)),
         data: antegen_thread_program::instruction::ThreadDelete { }.data(),
     };


### PR DESCRIPTION
### TL;DR
Added the ability to delete threads using their address in addition to their ID.

### What changed?
- Modified the thread delete command to accept either a thread ID or address
- Added a new `-k` or `--address` flag to specify thread address directly
- Updated the delete command to handle both ID and address-based deletion
- Made the thread ID parameter optional when using address

### How to test?
1. Delete a thread using its ID:
```bash
clockwork thread delete <THREAD_ID>
```

2. Delete a thread using its address:
```bash
clockwork thread delete -k <THREAD_ADDRESS>
```

### Why make this change?
This enhancement provides more flexibility when deleting threads. Users can now delete threads using either their ID or direct address, making it easier to manage threads when the address is known but the ID isn't readily available.