### PR TITLE
fix: :bug: mainnet fixes

### DIFF
--- a/programs/network/src/instructions/worker_update.rs
+++ b/programs/network/src/instructions/worker_update.rs
@@ -13,9 +13,6 @@ pub struct WorkerUpdate<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
 
-    #[account(address = system_program::ID)]
-    pub system_program: Program<'info, System>,
-
     #[account(
         mut,
         seeds = [
@@ -26,23 +23,26 @@ pub struct WorkerUpdate<'info> {
         has_one = authority,
     )]
     pub worker: Account<'info, Worker>,
+
+    #[account(address = system_program::ID)]
+    pub system_program: Program<'info, System>,
 }
 
 pub fn handler(ctx: Context<WorkerUpdate>, settings: WorkerSettings) -> Result<()> {
     // Get accounts
-    let authority = &ctx.accounts.authority;
-    let worker = &mut ctx.accounts.worker;
-    let system_program = &ctx.accounts.system_program;
+    let authority: &Signer = &ctx.accounts.authority;
+    let worker: &mut Account<Worker> = &mut ctx.accounts.worker;
+    let system_program: &Program<System> = &ctx.accounts.system_program;
 
     // Update the worker
     worker.update(settings)?;
 
     // Realloc memory for the worker account
-    let data_len = 8 + worker.try_to_vec()?.len();
+    let data_len: usize = 8 + worker.try_to_vec()?.len();
     worker.to_account_info().realloc(data_len, false)?;
 
     // If lamports are required to maintain rent-exemption, pay them
-    let minimum_rent = Rent::get().unwrap().minimum_balance(data_len);
+    let minimum_rent: u64 = Rent::get().unwrap().minimum_balance(data_len);
     if minimum_rent > worker.to_account_info().lamports() {
         transfer(
             CpiContext::new(

--- a/programs/thread/src/instructions/thread_create.rs
+++ b/programs/thread/src/instructions/thread_create.rs
@@ -5,7 +5,6 @@ use anchor_lang::{
     solana_program::system_program,
     system_program::{transfer, Transfer}
 };
-use antegen_network_program::ANTEGEN_SQUADS;
 use antegen_utils::thread::{Trigger, SerializableInstruction};
 
 use crate::{state::*, ThreadId};
@@ -15,13 +14,11 @@ const MINIMUM_FEE: u64 = 1000;
 
 /// Accounts required by the `thread_create` instruction.
 #[derive(Accounts)]
-#[instruction(amount: u64, id: ThreadId, instructions: Vec<SerializableInstruction>,  trigger: Trigger)]
+#[instruction(amount: u64, id: ThreadId, instructions: Vec<SerializableInstruction>, trigger: Trigger)]
 pub struct ThreadCreate<'info> {
     /// CHECK: the authority (owner) of the thread.
-    #[account(
-        constraint = authority.key().eq(&payer.key()) || authority.key().eq(&ANTEGEN_SQUADS)
-    )]
-    pub authority: UncheckedAccount<'info>,
+    #[account()]
+    pub authority: Signer<'info>,
 
     /// The payer for account initializations. 
     #[account(mut)]
@@ -64,7 +61,7 @@ pub fn handler(
     };
 
     // Get accounts
-    let authority: &UncheckedAccount = &ctx.accounts.authority;
+    let authority: &Signer = &ctx.accounts.authority;
     let payer: &Signer = &ctx.accounts.payer;
     let system_program: &Program<System> = &ctx.accounts.system_program;
     let thread: &mut Account<Thread> = &mut ctx.accounts.thread;


### PR DESCRIPTION
### TL;DR
Refactored worker creation and thread authorization logic, removing unnecessary dependencies and simplifying account validation.

### What changed?
- Removed unused dependencies from worker creation (associated_token, token program, config, rent sysvar)
- Simplified account validation in worker creation instruction
- Added explicit type annotations throughout worker-related code
- Modified thread creation to require authority signature instead of using ANTEGEN_SQUADS validation
- Reorganized account struct fields for better readability
- Streamlined worker update instruction account handling

### How to test?
1. Create a new worker using the CLI
2. Verify worker creation succeeds without associated token program
3. Update worker settings and confirm changes persist
4. Attempt to create a thread with different authority signatures
5. Verify thread creation only succeeds with proper authority signature

### Why make this change?
The original implementation included unnecessary dependencies and complex validation logic that wasn't required for worker operations. This change simplifies the codebase, improves type safety through explicit annotations, and strengthens security by requiring proper authority signatures for thread creation.