### PR TITLE
fix: :bug: increase txn buffer to 100_000

### DIFF
--- a/plugin/src/builders/thread_exec.rs
+++ b/plugin/src/builders/thread_exec.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
+use agave_geyser_plugin_interface::geyser_plugin_interface::{
+    GeyserPluginError, Result as PluginResult,
+};
 use anchor_lang::{InstructionData, ToAccountMetas};
-use antegen_thread_program::state::{VersionedThread, Trigger};
 use antegen_network_program::state::Worker;
+use antegen_thread_program::state::{Trigger, VersionedThread};
 use antegen_utils::thread::PAYER_PUBKEY;
 use log::info;
 use solana_account_decoder::UiAccountEncoding;
@@ -11,24 +14,18 @@ use solana_client::{
     rpc_config::{RpcSimulateTransactionAccountsConfig, RpcSimulateTransactionConfig},
     rpc_custom_error::JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
 };
-use agave_geyser_plugin_interface::geyser_plugin_interface::{
-    GeyserPluginError, Result as PluginResult,
-};
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
 };
 use solana_sdk::{
-    message::{
-        v0,
-        VersionedMessage
-    },
-    transaction::VersionedTransaction,
     account::Account,
     commitment_config::CommitmentConfig,
     compute_budget::ComputeBudgetInstruction,
+    message::{v0, VersionedMessage},
     signature::Keypair,
-    signer::Signer
+    signer::Signer,
+    transaction::VersionedTransaction,
 };
 
 /// Max byte size of a serialized transaction.
@@ -38,7 +35,7 @@ static TRANSACTION_MESSAGE_SIZE_LIMIT: usize = 1_232;
 static TRANSACTION_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
 /// The buffer amount to add to transactions' compute units in case on-chain PDA derivations take more CUs than used in simulation.
-static TRANSACTION_COMPUTE_UNIT_BUFFER: u32 = 1000;
+static TRANSACTION_COMPUTE_UNIT_BUFFER: u32 = 100_000;
 
 pub async fn build_thread_exec_tx(
     client: Arc<RpcClient>,
@@ -83,18 +80,16 @@ pub async fn build_thread_exec_tx(
         let message = v0::Message::try_compile(
             &signatory_pubkey,
             &ixs,
-            &[],  // address table lookups
+            &[], // address table lookups
             blockhash,
-        ).map_err(|e| {
+        )
+        .map_err(|e| {
             GeyserPluginError::Custom(format!("Failed to compile message: {}", e).into())
         })?;
 
         let versioned_message = VersionedMessage::V0(message);
         // Create versioned transaction
-        let sim_tx = VersionedTransaction::try_new(
-            versioned_message,
-            &[payer],
-        ).map_err(|e| {
+        let sim_tx = VersionedTransaction::try_new(versioned_message, &[payer]).map_err(|e| {
             GeyserPluginError::Custom(format!("Failed to create transaction: {}", e).into())
         })?;
 
@@ -127,10 +122,7 @@ pub async fn build_thread_exec_tx(
                 info!("Simulation error encountered: {:?}", err);
                 match err.kind {
                     solana_client::client_error::ClientErrorKind::RpcError(
-                        solana_client::rpc_request::RpcError::RpcResponseError {
-                            code,
-                            ..
-                        }
+                        solana_client::rpc_request::RpcError::RpcResponseError { code, .. },
                     ) if code == JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED => {
                         return Err(GeyserPluginError::Custom(
                             "RPC client has not reached min context slot".into(),
@@ -161,7 +153,7 @@ pub async fn build_thread_exec_tx(
                 let ui_account = match response
                     .value
                     .accounts
-                    .and_then(|a| a.get(0).cloned().flatten()) 
+                    .and_then(|a| a.get(0).cloned().flatten())
                 {
                     Some(acc) => acc,
                     None => {
@@ -239,20 +231,13 @@ pub async fn build_thread_exec_tx(
     }
 
     // Build final versioned transaction
-    let message = v0::Message::try_compile(
-        &signatory_pubkey,
-        &successful_ixs,
-        &[],
-        blockhash,
-    ).map_err(|e| {
-        GeyserPluginError::Custom(format!("Failed to compile final message: {}", e).into())
-    })?;
+    let message = v0::Message::try_compile(&signatory_pubkey, &successful_ixs, &[], blockhash)
+        .map_err(|e| {
+            GeyserPluginError::Custom(format!("Failed to compile final message: {}", e).into())
+        })?;
 
     let versioned_message = VersionedMessage::V0(message);
-    let tx = VersionedTransaction::try_new(
-        versioned_message,
-        &[payer],
-    ).map_err(|e| {
+    let tx = VersionedTransaction::try_new(versioned_message, &[payer]).map_err(|e| {
         GeyserPluginError::Custom(format!("Failed to create final transaction: {}", e).into())
     })?;
 
@@ -277,17 +262,15 @@ fn build_kickoff_ix(
 ) -> Instruction {
     // Build the instruction.
     let mut kickoff_ix = match thread {
-        VersionedThread::V1(_) => {
-            Instruction {
-                program_id: antegen_thread_program::ID,
-                accounts: antegen_thread_program::accounts::ThreadKickoff {
-                    signatory: signatory_pubkey,
-                    thread: thread_pubkey,
-                    worker: worker_pubkey,
-                }
-                .to_account_metas(Some(false)),
-                data: antegen_thread_program::instruction::ThreadKickoff {}.data(),
+        VersionedThread::V1(_) => Instruction {
+            program_id: antegen_thread_program::ID,
+            accounts: antegen_thread_program::accounts::ThreadKickoff {
+                signatory: signatory_pubkey,
+                thread: thread_pubkey,
+                worker: worker_pubkey,
             }
+            .to_account_metas(Some(false)),
+            data: antegen_thread_program::instruction::ThreadKickoff {}.data(),
         },
     };
 
@@ -297,24 +280,20 @@ fn build_kickoff_ix(
             address,
             offset: _,
             size: _,
-        } => {
-            kickoff_ix.accounts.push(AccountMeta {
-                pubkey: address,
-                is_signer: false,
-                is_writable: false,
-            })
-        },
+        } => kickoff_ix.accounts.push(AccountMeta {
+            pubkey: address,
+            is_signer: false,
+            is_writable: false,
+        }),
         Trigger::Pyth {
             price_feed,
             equality: _,
             limit: _,
-        } => {
-            kickoff_ix.accounts.push(AccountMeta {
-                pubkey: price_feed,
-                is_signer: false,
-                is_writable: false,
-            })
-        },
+        } => kickoff_ix.accounts.push(AccountMeta {
+            pubkey: price_feed,
+            is_signer: false,
+            is_writable: false,
+        }),
         _ => {}
     }
 
@@ -329,19 +308,17 @@ fn build_exec_ix(
 ) -> Instruction {
     // Build the instruction.
     let mut exec_ix = match thread {
-        VersionedThread::V1(_) => {
-            Instruction {
-                program_id: antegen_thread_program::ID,
-                accounts: antegen_thread_program::accounts::ThreadExec {
-                    commission: antegen_network_program::state::WorkerCommission::pubkey(worker_pubkey),
-                    pool: antegen_network_program::state::Pool::pubkey(0),
-                    signatory: signatory_pubkey,
-                    thread: thread_pubkey,
-                    worker: worker_pubkey,
-                }
-                .to_account_metas(Some(true)),
-                data: antegen_thread_program::instruction::ThreadExec {}.data(),
+        VersionedThread::V1(_) => Instruction {
+            program_id: antegen_thread_program::ID,
+            accounts: antegen_thread_program::accounts::ThreadExec {
+                commission: antegen_network_program::state::WorkerCommission::pubkey(worker_pubkey),
+                pool: antegen_network_program::state::Pool::pubkey(0),
+                signatory: signatory_pubkey,
+                thread: thread_pubkey,
+                worker: worker_pubkey,
             }
+            .to_account_metas(Some(true)),
+            data: antegen_thread_program::instruction::ThreadExec {}.data(),
         },
     };
 


### PR DESCRIPTION
### TL;DR

Increased the transaction compute unit buffer from 1,000 to 100,000 to provide more headroom for on-chain PDA derivations.

### What changed?

This PR increases the `TRANSACTION_COMPUTE_UNIT_BUFFER` constant from 1,000 to 100,000. This buffer is added to transaction compute units to account for potential differences between simulation and actual execution, particularly for on-chain PDA derivations that might require more compute units than estimated during simulation.

The PR also includes some code formatting changes and import reorganization, but no functional changes beyond the compute unit buffer increase.

### How to test?

1. Deploy the updated plugin
2. Monitor thread executions that previously failed due to compute unit limits
3. Verify that transactions now have sufficient compute units to complete successfully
4. Check logs to ensure no more compute budget exceeded errors occur

### Why make this change?

The previous buffer of 1,000 compute units was insufficient for some complex thread executions, leading to transactions failing on-chain despite successful simulation. By increasing the buffer to 100,000, we provide significantly more headroom for operations that might require additional compute units during actual execution, improving the reliability of thread executions.