### PR TITLE
chore: clear clippy lint allow list down to non-fixable cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-fiber-program"
-version = "5.1.0"
+version = "6.0.0"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-thread-program"
-version = "5.1.0"
+version = "6.0.0"
 dependencies = [
  "anchor-lang",
  "antegen-cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,14 +62,14 @@ large_enum_variant = "allow"
 
 [workspace.dependencies]
 # Internal workspace crates (each has its own version)
-antegen-cli-core = { version = "6.0.0", path = "cli/core" }
+antegen-cli-core = { version = "6.1.0", path = "cli/core" }
 antegen-cron = { version = "4.0.0", path = "crates/cron" }
-antegen-client = { version = "5.0.4", path = "crates/client" }
-antegen-geyser-plugin = { version = "5.0.0", path = "plugin/geyser" }
-antegen-fiber-program = { version = "5.0.4", path = "programs/fiber", features = [
+antegen-client = { version = "5.2.0", path = "crates/client" }
+antegen-geyser-plugin = { version = "5.1.0", path = "plugin/geyser" }
+antegen-fiber-program = { version = "6.0.0", path = "programs/fiber", features = [
     "cpi",
 ] }
-antegen-thread-program = { version = "5.0.6", path = "programs/thread", features = [
+antegen-thread-program = { version = "6.0.0", path = "programs/thread", features = [
     "cpi",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,38 +48,17 @@ unexpected_cfgs = { level = "allow", check-cfg = [
   'cfg(target_os, values("solana"))',
 ] }
 
-# Workspace-wide clippy lint configuration. The allow list covers two
-# categories:
+# Workspace-wide clippy lint configuration. Allowed lints fall into two
+# categories that aren't worth fighting:
 #   1. Lints that fire on Anchor's `#[program]` macro expansion
 #      (`diverging_sub_expression`) — not actionable in user code.
 #   2. Lints whose "fix" would change a public ix signature or a stable
-#      API shape (`too_many_arguments`, `result_large_err`,
-#      `large_enum_variant`, `len_without_is_empty`).
-#   3. Style lints with established codebase patterns. These can be
-#      re-enabled by tightening the allow list once the codebase has been
-#      walked through.
+#      API shape (`too_many_arguments`, `large_enum_variant`).
 # Crates inherit via `[lints] workspace = true` in their Cargo.toml.
 [workspace.lints.clippy]
-# Anchor macro / API-shape lints.
 diverging_sub_expression = "allow"
 too_many_arguments = "allow"
 large_enum_variant = "allow"
-# Style lints firing in `crates/client` actors — addressable in a future
-# code-quality pass; not worth churning ALT support PR over.
-needless_borrow = "allow"
-needless_borrows_for_generic_args = "allow"
-unnecessary_map_or = "allow"
-cloned_ref_to_slice_refs = "allow"
-manual_is_multiple_of = "allow"
-# Style lints firing in `cli/core` — same rationale as the client allows.
-derivable_impls = "allow"
-if_same_then_else = "allow"
-missing_safety_doc = "allow"
-ptr_arg = "allow"
-redundant_closure = "allow"
-trim_split_whitespace = "allow"
-manual_strip = "allow"
-cmp_owned = "allow"
 
 [workspace.dependencies]
 # Internal workspace crates (each has its own version)

--- a/cli/antegen/src/commands/geyser.rs
+++ b/cli/antegen/src/commands/geyser.rs
@@ -5,7 +5,7 @@ use antegen_cli_core::download::{
 };
 use antegen_client::ClientConfig;
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Initialize Geyser plugin for validator
 pub async fn init(output: PathBuf, config_path: PathBuf) -> Result<()> {
@@ -36,7 +36,7 @@ pub async fn init(output: PathBuf, config_path: PathBuf) -> Result<()> {
     // Determine config file path
     // If default "antegen.toml", put it in the plugin directory
     // Otherwise use the user-specified path
-    let final_config_path = if config_path == PathBuf::from("antegen.toml") {
+    let final_config_path = if config_path == Path::new("antegen.toml") {
         plugin_dir.join("antegen.toml")
     } else {
         config_path

--- a/cli/core/src/commands/mod.rs
+++ b/cli/core/src/commands/mod.rs
@@ -56,10 +56,10 @@ pub fn default_config_path() -> Result<PathBuf> {
 
 /// Expand ~ in path to home directory
 pub fn expand_tilde(path: &str) -> Result<PathBuf> {
-    if path.starts_with("~/") {
+    if let Some(stripped) = path.strip_prefix("~/") {
         let home = dirs::home_dir()
             .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-        Ok(home.join(&path[2..]))
+        Ok(home.join(stripped))
     } else {
         Ok(PathBuf::from(path))
     }

--- a/cli/core/src/commands/run.rs
+++ b/cli/core/src/commands/run.rs
@@ -97,12 +97,7 @@ fn find_node_binary() -> Result<PathBuf> {
     #[cfg(not(feature = "prod"))]
     if let Ok(current_exe) = std::env::current_exe() {
         let path_str = current_exe.to_string_lossy();
-        if path_str.contains("/target/debug/") {
-            let candidate = current_exe.with_file_name("antegen-node");
-            if candidate.exists() {
-                return Ok(candidate);
-            }
-        } else if path_str.contains("/target/release/") {
+        if path_str.contains("/target/debug/") || path_str.contains("/target/release/") {
             let candidate = current_exe.with_file_name("antegen-node");
             if candidate.exists() {
                 return Ok(candidate);

--- a/cli/core/src/commands/service.rs
+++ b/cli/core/src/commands/service.rs
@@ -7,7 +7,7 @@ use service_manager::{
 };
 use std::ffi::OsString;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Service label for antegen
 const SERVICE_LABEL: &str = "antegen";
@@ -141,7 +141,7 @@ fn do_init(rpc: Option<String>, force: bool) -> Result<PathBuf> {
 
 /// Install the service (helper for start command).
 /// Uses the `antegen-node` binary directly instead of the CLI binary.
-async fn install_service(config_path: &PathBuf, version: Option<&str>) -> Result<()> {
+async fn install_service(config_path: &Path, version: Option<&str>) -> Result<()> {
     let manager = get_service_manager()?;
     let label = get_label()?;
 

--- a/cli/core/src/commands/update.rs
+++ b/cli/core/src/commands/update.rs
@@ -253,7 +253,7 @@ pub fn import_node_binary() -> Result<()> {
         let mut dir = current_exe.parent().map(|p| p.to_path_buf());
         loop {
             match dir {
-                Some(ref d) if d.file_name().map_or(false, |n| n == "target") => {
+                Some(ref d) if d.file_name().is_some_and(|n| n == "target") => {
                     break d.join("release/antegen-node");
                 }
                 Some(ref d) if d.parent().is_some() => {
@@ -276,10 +276,9 @@ pub fn import_node_binary() -> Result<()> {
         .context("Failed to run antegen-node --version")?;
     let version_str = String::from_utf8_lossy(&output.stdout);
     let version = version_str
-        .trim()
         .split_whitespace()
         .last()
-        .map(|v| normalize_version(v))
+        .map(normalize_version)
         .context("Could not parse node version")?;
 
     let versioned_path = versioned_node_binary_path(&version)?;
@@ -823,7 +822,7 @@ fn detect_local_node_build() -> Option<(PathBuf, String)> {
     let version = version_output
         .split_whitespace()
         .nth(1)
-        .map(|v| normalize_version(v))?;
+        .map(normalize_version)?;
 
     Some((built_binary, version))
 }
@@ -867,7 +866,7 @@ pub fn cargo_build_and_install_node() -> Result<String> {
     let version = version_output
         .split_whitespace()
         .nth(1)
-        .map(|v| normalize_version(v))
+        .map(normalize_version)
         .context("Failed to parse version from built binary")?;
 
     // Copy to versioned path (don't use install_binary_to — it deletes the source)
@@ -933,7 +932,7 @@ pub async fn update_node(version: Option<String>, local: bool) -> Result<()> {
     }
 
     let installed = get_installed_node_version()
-        .or_else(|| read_node_version())
+        .or_else(read_node_version)
         .unwrap_or_else(|| "none".to_string());
     println!("Installed node version: {}", installed);
 
@@ -1131,7 +1130,7 @@ pub async fn list_cli(remote: bool) -> Result<()> {
     // If symlink → ~/.local/bin/antegen-v5.0.0, that managed version is active
     let cargo_is_active = symlink_target
         .as_ref()
-        .map_or(false, |t| t.to_string_lossy().contains(".cargo/bin/"));
+        .is_some_and(|t| t.to_string_lossy().contains(".cargo/bin/"));
     let managed_active = if !cargo_is_active {
         symlink_target.as_ref().and_then(|t| {
             t.file_name()?
@@ -1233,7 +1232,7 @@ pub async fn download_latest_node() -> Result<()> {
 /// Shows installed versions, local cargo build (if detected), and available remote versions.
 pub async fn list_node() -> Result<()> {
     let bin_dir = bin_dir()?;
-    let active_version = get_installed_node_version().or_else(|| read_node_version());
+    let active_version = get_installed_node_version().or_else(read_node_version);
 
     // Detect local cargo build
     let local_build = detect_local_node_build();

--- a/crates/client/src/actors/root.rs
+++ b/crates/client/src/actors/root.rs
@@ -217,7 +217,7 @@ impl Actor for RootSupervisor {
 /// Spawn a background task to listen for SIGINT and SIGTERM signals
 fn spawn_signal_handler(root: ActorRef<RootMessage>) {
     tokio::spawn(async move {
-        let mut signals = match Signals::new(&[SIGINT, SIGTERM]) {
+        let mut signals = match Signals::new([SIGINT, SIGTERM]) {
             Ok(s) => s,
             Err(e) => {
                 log::error!("Failed to create signal handler: {}", e);

--- a/crates/client/src/actors/staging.rs
+++ b/crates/client/src/actors/staging.rs
@@ -304,7 +304,7 @@ impl StagingActor {
         state.last_processed_slot = clock.slot;
 
         // Periodic heartbeat at INFO level every 100 slots
-        if clock.slot % 100 == 0 {
+        if clock.slot.is_multiple_of(100) {
             info!(
                 "ClockTick heartbeat: slot={}, tracked={}, queued={}",
                 clock.slot,
@@ -315,14 +315,14 @@ impl StagingActor {
 
         // Periodic load balancer pruning every 1000 slots (~7 minutes)
         // Removes tracking entries for threads that no longer exist
-        if clock.slot % 1000 == 0 {
+        if clock.slot.is_multiple_of(1000) {
             let known_threads: HashSet<Pubkey> = state.tracked_threads.keys().copied().collect();
             state.load_balancer.prune_stale(&known_threads).await;
         }
 
         // Periodic priority queue compaction every 500 slots (~3.5 minutes)
         // Removes stale entries where exec_count no longer matches or thread is untracked
-        if clock.slot % 500 == 0 {
+        if clock.slot.is_multiple_of(500) {
             self.compact_queues(state).await;
         }
 

--- a/crates/client/src/actors/worker.rs
+++ b/crates/client/src/actors/worker.rs
@@ -627,7 +627,7 @@ async fn submit_and_confirm_batch(
 
                         let _ = load_balancer
                             .record_execution_result(
-                                &thread_pubkey,
+                                thread_pubkey,
                                 false,
                                 chrono::Utc::now().timestamp(),
                             )
@@ -654,7 +654,7 @@ async fn submit_and_confirm_batch(
 
             // Record success in load balancer
             let _ = load_balancer
-                .record_execution_result(&thread_pubkey, true, chrono::Utc::now().timestamp())
+                .record_execution_result(thread_pubkey, true, chrono::Utc::now().timestamp())
                 .await;
 
             return Ok(signature);
@@ -676,7 +676,7 @@ async fn submit_and_confirm_batch(
 
                 // Record loss in load balancer
                 let _ = load_balancer
-                    .record_execution_result(&thread_pubkey, false, chrono::Utc::now().timestamp())
+                    .record_execution_result(thread_pubkey, false, chrono::Utc::now().timestamp())
                     .await;
 
                 tokio::time::sleep(Duration::from_millis(
@@ -697,7 +697,7 @@ async fn submit_and_confirm_batch(
 
                 // Record success in load balancer
                 let _ = load_balancer
-                    .record_execution_result(&thread_pubkey, true, chrono::Utc::now().timestamp())
+                    .record_execution_result(thread_pubkey, true, chrono::Utc::now().timestamp())
                     .await;
 
                 return Ok(signature);
@@ -728,7 +728,7 @@ async fn submit_and_confirm_batch(
                     // Only record loss for non-6004 errors
                     let _ = load_balancer
                         .record_execution_result(
-                            &thread_pubkey,
+                            thread_pubkey,
                             false,
                             chrono::Utc::now().timestamp(),
                         )

--- a/crates/client/src/executor.rs
+++ b/crates/client/src/executor.rs
@@ -141,7 +141,7 @@ impl ExecutorLogic {
         );
 
         // Verify single instruction fits in a transaction
-        if !self.would_fit_in_transaction(&[first_ix.clone()]) {
+        if !self.would_fit_in_transaction(std::slice::from_ref(&first_ix)) {
             return Err(anyhow!(
                 "Single instruction exceeds max transaction size for thread {}",
                 thread_pubkey

--- a/crates/client/src/load_balancer.rs
+++ b/crates/client/src/load_balancer.rs
@@ -153,7 +153,7 @@ impl LoadBalancer {
         let thread_track = tracking.get(thread_pubkey);
         let at_capacity = *self.at_capacity.read().await;
 
-        if thread_track.map_or(false, |t| t.owned) {
+        if thread_track.is_some_and(|t| t.owned) {
             // We own this thread - always try to process
             Ok(ProcessDecision::Process)
         } else if is_overdue && overdue_seconds > self.config.thread_takeover_delay {

--- a/plugin/geyser/src/lib.rs
+++ b/plugin/geyser/src/lib.rs
@@ -12,7 +12,7 @@ use solana_program::pubkey::Pubkey;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AntegenPlugin {
     inner: Option<Arc<Inner>>,
 }
@@ -180,12 +180,13 @@ impl GeyserPlugin for AntegenPlugin {
     }
 }
 
-impl Default for AntegenPlugin {
-    fn default() -> Self {
-        Self { inner: None }
-    }
-}
-
+/// Geyser entry point. Validators dlopen the plugin and call this symbol
+/// to construct the plugin instance.
+///
+/// # Safety
+/// The returned pointer must be released by the validator via
+/// `Box::from_raw`. The function is unsafe because it crosses the FFI
+/// boundary and the validator owns the lifetime of the returned plugin.
 #[no_mangle]
 #[allow(improper_ctypes_definitions)]
 pub unsafe extern "C" fn _create_plugin() -> *mut dyn GeyserPlugin {


### PR DESCRIPTION
## Summary

Walks through the ~15-entry `[workspace.lints.clippy]` allow list that
PR #32 landed (so its CI could stay green while the ALT support work
was reviewed) and either fixes the underlying code or drops the entry.

After this PR, the allow list is down to 3 genuinely non-fixable cases:

- `diverging_sub_expression` — Anchor's `#[program]` macro expansion
- `too_many_arguments` — would re-shape public ix signatures
  (`create_thread`, `update_fiber`)
- `large_enum_variant` — Anchor instruction enums are big by design

Everything else gets a mechanical fix. No behavior changes.

## Diff highlights

- `crates/client/`: needless `&` drops, `% N == 0` →
  `.is_multiple_of(N)`, `&[ix.clone()]` → `std::slice::from_ref`,
  `.map_or(false, ...)` → `.is_some_and(...)`.
- `plugin/geyser/src/lib.rs`: derive `Default`; add `# Safety` section
  to the `_create_plugin` FFI symbol.
- `cli/core/`: collapsed duplicate `if/else if`, `&PathBuf` → `&Path`,
  `.map(|v| f(v))` → `.map(f)`, manual prefix slicing → `strip_prefix`.
- `cli/antegen/`: owned `PathBuf` comparison → borrowed `Path::new`.

## Test plan

- [x] `cargo clippy --workspace --lib --bins -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace --locked` — all tests pass

## Follow-up

Once this lands, PR 2 (executor v0 + ALT consumption) starts from a
clean clippy baseline.