### PR TITLE
ci(release): pin verify image, add executable-hash, rollback on failure

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,8 +66,11 @@ jobs:
 
   # -----------------------------------------------------------------------
   # Stage 2: solana-verify build for each released program. Attaches the
-  # verifiable .so + sha256 to the program's GitHub Release so downstream
-  # consumers (e.g. srsly) can fetch reproducible binaries.
+  # verifiable .so + sha256 + executable-hash to the program's GitHub
+  # Release so downstream consumers (e.g. srsly) can fetch reproducible
+  # binaries. If the verify build fails the partial release + tag are
+  # deleted in the failure step at the bottom of this job so we never
+  # leave a hollow release behind.
   # -----------------------------------------------------------------------
   verifiable-build:
     name: solana-verify build
@@ -84,11 +87,9 @@ jobs:
       matrix:
         include:
           - program: antegen_thread_program
-            released_flag: thread_released
-            tag_output: thread_tag
+            program_id: AgTv5w1UvUb6zeqkThwMrztGu9hpepBu8YLghuR4dpSx
           - program: antegen_fiber_program
-            released_flag: fiber_released
-            tag_output: fiber_tag
+            program_id: AgFv5afjW9DmSPkiEvJ1er5bAAmRUqaBeTB6Cr8e1hKx
     steps:
       - name: Resolve release flag for this program
         id: gate
@@ -117,13 +118,115 @@ jobs:
         run: cargo install solana-verify --locked
 
       - name: Run solana-verify build
+        # Pin to a recent solana-verifiable-build image so the in-image
+        # cargo is >= 1.85 — older images ship 1.84 and cannot parse
+        # `edition2024` manifests pulled in by transitive proc-macros
+        # (proc-macro-crate >= 3.5 → toml_edit >= 0.25). Bump this tag
+        # periodically.
         if: steps.gate.outputs.released == 'true'
-        run: solana-verify build --library-name ${{ matrix.program }}
+        run: solana-verify build --library-name ${{ matrix.program }} --base-image solanafoundation/solana-verifiable-build:3.1.14
 
-      - name: Compute sha256
+      - name: Reclaim solana-verify output ownership
+        # solana-verify runs cargo inside a Docker container as root, so
+        # everything it writes into the mounted `target/deploy/` ends up
+        # owned by root. The runner user can't write the .sha256 file
+        # alongside without this chown — `tee` would fail with
+        # "Permission denied".
         if: steps.gate.outputs.released == 'true'
+        run: sudo chown -R "$USER" target/deploy
+
+      - name: Compute hashes
+        # Two complementary hashes published alongside the .so:
+        #   .sha256          — standard `sha256sum` of the file. Matches the
+        #                      sha256 GitHub renders for the release asset.
+        #                      Verify with `sha256sum -c <name>.so.sha256`.
+        #   .executable-hash — `solana-verify get-executable-hash` output:
+        #                      the .so with ELF metadata + trailing zeros
+        #                      stripped, matching what
+        #                      `solana-verify get-program-hash <program-id>`
+        #                      returns for the deployed program. Lets a
+        #                      consumer compare the release artifact against
+        #                      live on-chain state.
+        if: steps.gate.outputs.released == 'true'
+        working-directory: target/deploy
         run: |
-          shasum -a 256 target/deploy/${{ matrix.program }}.so | tee target/deploy/${{ matrix.program }}.so.sha256
+          sha256sum ${{ matrix.program }}.so | tee ${{ matrix.program }}.so.sha256
+          solana-verify get-executable-hash ${{ matrix.program }}.so | tee ${{ matrix.program }}.so.executable-hash
+
+      - name: Compose verification footer
+        # Appended to the release body (below release-please's changelog)
+        # so consumers see exact verification commands inline. Embeds the
+        # file hashes computed above and the on-chain program ID so a
+        # reader can paste-and-run.
+        if: steps.gate.outputs.released == 'true'
+        working-directory: target/deploy
+        run: |
+          FILE_SHA="$(awk '{print $1}' ${{ matrix.program }}.so.sha256)"
+          EXEC_HASH="$(cat ${{ matrix.program }}.so.executable-hash)"
+          COMMIT="${{ github.sha }}"
+          cat > verify-footer.md <<EOF
+
+          ---
+
+          ## Verifying this release
+
+          This release attaches the on-chain program binary
+          \`${{ matrix.program }}.so\` for program ID
+          \`${{ matrix.program_id }}\` along with two hash files. Both are
+          worth checking — they answer different questions.
+
+          ### 1. Did the binary I downloaded arrive intact?
+
+          Standard \`sha256sum\` of the file, matching the \`sha256:…\`
+          GitHub renders next to each release asset:
+
+          \`\`\`
+          $FILE_SHA  ${{ matrix.program }}.so
+          \`\`\`
+
+          \`\`\`bash
+          sha256sum -c ${{ matrix.program }}.so.sha256
+          # → ${{ matrix.program }}.so: OK
+          \`\`\`
+
+          ### 2. Does this binary match what's deployed on-chain?
+
+          \`solana-verify get-executable-hash\` strips ELF metadata +
+          trailing zeros so the hash matches what
+          \`solana-verify get-program-hash\` returns for a live program
+          account:
+
+          \`\`\`
+          $EXEC_HASH
+          \`\`\`
+
+          \`\`\`bash
+          # Compare the artifact's hash to the deployed program's hash.
+          diff \\
+            <(cat ${{ matrix.program }}.so.executable-hash) \\
+            <(solana-verify get-program-hash ${{ matrix.program_id }} -u mainnet-beta)
+          # → no output = match
+          \`\`\`
+
+          ### 3. Did the binary actually come from this source tree?
+
+          Reproduce the build locally with the same Docker image
+          (\`solanafoundation/solana-verifiable-build:3.1.14\`):
+
+          \`\`\`bash
+          git clone https://github.com/${{ github.repository }} && cd antegen
+          git checkout $COMMIT
+          solana-verify build \\
+            --library-name ${{ matrix.program }} \\
+            --base-image solanafoundation/solana-verifiable-build:3.1.14
+          solana-verify get-executable-hash target/deploy/${{ matrix.program }}.so
+          # Should equal: $EXEC_HASH
+          \`\`\`
+
+          For full details on the verified-build pipeline, see
+          [solana.com/docs/programs/verified-builds](https://solana.com/docs/programs/verified-builds).
+          EOF
+          cat verify-footer.md
 
       - name: Upload workflow artifacts
         if: steps.gate.outputs.released == 'true'
@@ -133,6 +236,7 @@ jobs:
           path: |
             target/deploy/${{ matrix.program }}.so
             target/deploy/${{ matrix.program }}.so.sha256
+            target/deploy/${{ matrix.program }}.so.executable-hash
           retention-days: 7
 
       - name: Attach to GitHub Release
@@ -143,7 +247,24 @@ jobs:
           files: |
             target/deploy/${{ matrix.program }}.so
             target/deploy/${{ matrix.program }}.so.sha256
-          append_body: false
+            target/deploy/${{ matrix.program }}.so.executable-hash
+          body_path: target/deploy/verify-footer.md
+          append_body: true
+
+      - name: Rollback release + tag on failure
+        # release-please creates the GitHub Release + tag before this job
+        # runs, so a failed verify build would otherwise leave behind a
+        # release with no binary and a tag pointing at code that never
+        # produced a verifiable artifact. Delete both so the next push
+        # to main starts fresh from release-please.
+        if: ${{ failure() && steps.gate.outputs.released == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Verifiable build failed for ${{ matrix.program }}. Deleting empty release + tag ${{ steps.gate.outputs.tag }}."
+          gh release delete "${{ steps.gate.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --cleanup-tag --yes || true
 
   # -----------------------------------------------------------------------
   # Stage 3: Publish library + program crates to crates.io in topo order.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-fiber-program"
-version = "5.1.0"
+version = "6.0.0"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-thread-program"
-version = "5.1.0"
+version = "6.0.0"
 dependencies = [
  "anchor-lang",
  "antegen-cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,14 +83,14 @@ cmp_owned = "allow"
 
 [workspace.dependencies]
 # Internal workspace crates (each has its own version)
-antegen-cli-core = { version = "6.0.0", path = "cli/core" }
+antegen-cli-core = { version = "6.1.0", path = "cli/core" }
 antegen-cron = { version = "4.0.0", path = "crates/cron" }
-antegen-client = { version = "5.0.4", path = "crates/client" }
-antegen-geyser-plugin = { version = "5.0.0", path = "plugin/geyser" }
-antegen-fiber-program = { version = "5.0.4", path = "programs/fiber", features = [
+antegen-client = { version = "5.2.0", path = "crates/client" }
+antegen-geyser-plugin = { version = "5.1.0", path = "plugin/geyser" }
+antegen-fiber-program = { version = "6.0.0", path = "programs/fiber", features = [
     "cpi",
 ] }
-antegen-thread-program = { version = "5.0.6", path = "programs/thread", features = [
+antegen-thread-program = { version = "6.0.0", path = "programs/thread", features = [
     "cpi",
 ] }
 


### PR DESCRIPTION
## Summary

Three changes to the program verifiable-build job in
`release-please.yml`, all borrowed from the parallel pipeline in
`wuwei-labs/srsly`. Together they:

- Stop the verify build from rotting on toolchain mismatches
- Give downstream consumers (e.g. srsly) enough info to verify the
  release matches what's deployed on-chain
- Stop empty releases from piling up when a verify build fails

## Why now

Right now `antegen-thread-program-v6.0.0` and
`antegen-fiber-program-v6.0.0` are both empty GitHub Releases because
the verify build failed against the default `solana-verify` image
(cargo 1.84 vs `edition2024` from a transitive proc-macro dep).
release-please created the release + tag before that job ran, so the
shell stayed behind with nothing inside.

## What changes

1. **Pin the solana-verify base image** to
   `solanafoundation/solana-verifiable-build:3.1.14` so the in-image
   cargo is recent enough to parse `edition2024` manifests. Bump the
   tag periodically.

2. **Publish two complementary hashes** alongside the `.so`:
   - `.sha256` — `sha256sum` of the file, matches the asset hash
     GitHub renders. Answers _"did the download arrive intact?"_
   - `.executable-hash` — `solana-verify get-executable-hash`, which
     strips ELF metadata + trailing zeros to match
     `solana-verify get-program-hash <program-id>` for the deployed
     program account. Answers _"does this binary match the on-chain
     program?"_

   A `verify-footer.md` is composed inline and appended to the
   release body with paste-and-run instructions for both hashes plus
   a reproduce-the-build recipe pinned to the source commit.

3. **Rollback on verify failure**. An `if: failure()` step at the
   bottom of the matrix entry deletes the GitHub Release + tag for
   the program whose build failed. Scoped per matrix entry so a
   thread-only failure won't delete the fiber release. release-please
   will re-open its release PR on the next push to main, so the
   normal flow recovers automatically.

## Test plan

The workflow only runs on `push` to `main` after a release-please PR
is merged, so it can't be exercised on this PR directly. Once merged,
the next release PR will:

- Drop into the pinned base image
- Produce the dual hashes
- Attach them + the verify footer to the GitHub Release
- Delete the release + tag if any of the above fail

## Follow-up

The existing empty `antegen-thread-program-v6.0.0` and
`antegen-fiber-program-v6.0.0` releases still need to be deleted
manually since they predate the rollback. Holding on that — needs an
explicit go-ahead.