### PR TITLE
fix(release): roll thread/fiber manifest back to 5.1.0 to re-cut v6.0.0

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,8 +1,8 @@
 {
   "crates/cron": "4.1.0",
   "crates/client": "5.2.0",
-  "programs/thread": "6.0.0",
-  "programs/fiber": "6.0.0",
+  "programs/thread": "5.1.0",
+  "programs/fiber": "5.1.0",
   "cli/core": "6.1.0",
   "cli/antegen": "6.1.0",
   "cli/antegenctl": "6.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-fiber-program"
-version = "6.0.0"
+version = "5.1.0"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-thread-program"
-version = "6.0.0"
+version = "5.1.0"
 dependencies = [
  "anchor-lang",
  "antegen-cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,10 @@ antegen-cli-core = { version = "6.1.0", path = "cli/core" }
 antegen-cron = { version = "4.0.0", path = "crates/cron" }
 antegen-client = { version = "5.2.0", path = "crates/client" }
 antegen-geyser-plugin = { version = "5.1.0", path = "plugin/geyser" }
-antegen-fiber-program = { version = "6.0.0", path = "programs/fiber", features = [
+antegen-fiber-program = { version = "5.1.0", path = "programs/fiber", features = [
     "cpi",
 ] }
-antegen-thread-program = { version = "6.0.0", path = "programs/thread", features = [
+antegen-thread-program = { version = "5.1.0", path = "programs/thread", features = [
     "cpi",
 ] }
 

--- a/programs/fiber/CHANGELOG.md
+++ b/programs/fiber/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## [6.0.0](https://github.com/wuwei-labs/antegen/compare/antegen-fiber-program-v5.1.0...antegen-fiber-program-v6.0.0) (2026-05-17)
-
-
-### ⚠ BREAKING CHANGES
-
-* **fiber:** `create` and `update` ix surfaces gain a required parameter; consumers must rebuild against the new IDL.
-
-### Features
-
-* **fiber:** add versioned Fiber state with lookup_tables ([6b1a7b0](https://github.com/wuwei-labs/antegen/commit/6b1a7b0c6e400c6aa790558e2cb780560af0d494))
-
 ## [5.1.0](https://github.com/wuwei-labs/antegen/compare/antegen-fiber-program-v5.0.7...antegen-fiber-program-v5.1.0) (2026-05-17)
 
 

--- a/programs/fiber/Cargo.toml
+++ b/programs/fiber/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "antegen-fiber-program"
 description = "Solana program for Antegen - fiber (instruction) account management"
-version = "6.0.0"
+version = "5.1.0"
 authors = ["Antegen Maintainers <maintainers@antegen.xyz>"]
 repository = "https://github.com/wuwei-labs/antegen"
 homepage = "https://antegen.xyz/"

--- a/programs/thread/CHANGELOG.md
+++ b/programs/thread/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## [6.0.0](https://github.com/wuwei-labs/antegen/compare/antegen-thread-program-v5.1.0...antegen-thread-program-v6.0.0) (2026-05-17)
-
-
-### ⚠ BREAKING CHANGES
-
-* **thread:** `create_thread`, `create_fiber`, `update_fiber` instructions gain required `lookup_tables` parameters. The `fiber`, `target`, and `source` accounts on close / swap / exec are now untyped — consumers building the transaction by hand are unaffected, but anyone using Anchor's typed `Account` wrappers must update.
-
-### Features
-
-* **thread:** forward lookup_tables through fiber CPIs ([19eb27b](https://github.com/wuwei-labs/antegen/commit/19eb27ba1f2b6877104be916a87565cb74dc20b9))
-
 ## [5.1.0](https://github.com/wuwei-labs/antegen/compare/antegen-thread-program-v5.0.12...antegen-thread-program-v5.1.0) (2026-05-17)
 
 

--- a/programs/thread/Cargo.toml
+++ b/programs/thread/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "antegen-thread-program"
 description = "Solana program for Antegen - automation and scheduling threads"
-version = "6.0.0"
+version = "5.1.0"
 authors = ["Antegen Maintainers <maintainers@antegen.xyz>"]
 repository = "https://github.com/wuwei-labs/antegen"
 homepage = "https://antegen.xyz/"


### PR DESCRIPTION
## Summary

release-please opened PR #36 proposing
`antegen-thread-program`/`antegen-fiber-program` v7.0.0 because:

1. The `*-v6.0.0` GitHub Releases were empty (verify build failed) and
   their tags were deleted manually.
2. The manifest still recorded thread/fiber at 6.0.0.
3. release-please couldn't find the v6.0.0 tag, walked history from the
   nearest prior tag (v5.1.0), and re-counted the ALT-support breaking
   commits — proposing a phantom v7.0.0 bump.

Roll thread + fiber back to 5.1.0 in `.github/.release-please-manifest.json`
so release-please re-evaluates against the still-intact `*-v5.1.0` tags
and re-cuts a clean v6.0.0 with the breaking ALT changelog. The new
verify pipeline from #35 (pinned base image, dual hashes, auto-rollback)
will populate the assets correctly this time.

## Test plan

- [ ] Merge this PR
- [ ] Close PR #36 (phantom v7.0.0 proposal) so release-please regenerates
- [ ] Wait for release-please workflow to re-open a release PR cutting
      thread/fiber v6.0.0
- [ ] Merge the new release PR
- [ ] Verify the new verify pipeline attaches `.so`, `.sha256`, and
      `.executable-hash` to both program releases