### PR TITLE
feat(client)!: build v0 transactions with batched fiber ALTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,7 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger 0.10.2",
  "futures",
+ "indexmap",
  "loa-core",
  "log",
  "moka",
@@ -575,6 +576,7 @@ dependencies = [
  "signal-hook-tokio",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
+ "solana-address-lookup-table-interface",
  "solana-compute-budget-interface",
  "solana-program",
  "solana-rpc-client",
@@ -600,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-fiber-program"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -635,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "antegen-thread-program"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "anchor-lang",
  "antegen-cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ futures = "=0.3.31"
 getrandom = { version = "=0.2.16", features = ["custom"] }
 hex = "=0.4.3"
 hyper = { version = "=0.14.32", features = ["server", "tcp", "http1"] }
+indexmap = "=2.13.0"
 lazy_static = "=1.5.0"
 loa-core = "=2.0.1"
 log = "=0.4.29"
@@ -136,6 +137,7 @@ uuid = { version = "=1.19.0", features = ["v4", "serde"] }
 # Solana dependencies - pinned to resolved versions
 solana-account-decoder = "=3.1.4"
 solana-account-decoder-client-types = "=3.1.4"
+solana-address-lookup-table-interface = "=3.0.1"
 solana-cli-config = "=3.1.4"
 solana-compute-budget-interface = "=3.0.0"
 solana-logger = "=3.0.0"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -37,6 +37,7 @@ chrono = { workspace = true }
 bincode = { workspace = true }
 solana-account-decoder-client-types = { workspace = true }
 solana-account-decoder = { workspace = true }
+solana-address-lookup-table-interface = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-system-interface = { workspace = true }
 bs58 = { workspace = true }
@@ -51,6 +52,9 @@ base64 = "0.22"
 
 # Efficient synchronization primitives
 parking_lot = "0.12"
+
+# Ordered ALT union accumulation in the executor batcher
+indexmap = { workspace = true }
 
 # Error handling
 thiserror = "1.0"

--- a/crates/client/src/actors/worker.rs
+++ b/crates/client/src/actors/worker.rs
@@ -17,8 +17,12 @@ use antegen_thread_program::state::Thread;
 use ractor::{Actor, ActorProcessingErr, ActorRef};
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_sdk::{
-    clock::Clock, instruction::Instruction, message::Message, pubkey::Pubkey, signature::Signature,
-    transaction::Transaction,
+    clock::Clock,
+    instruction::Instruction,
+    message::{v0, AddressLookupTableAccount, Message, VersionedMessage},
+    pubkey::Pubkey,
+    signature::Signature,
+    transaction::{Transaction, VersionedTransaction},
 };
 use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -318,7 +322,13 @@ async fn execute_thread(
         }
 
         // Build batch — first iteration uses trigger retry, subsequent don't need it
-        let (ixs, priority_fee, needs_continuation, next_cursor) = if batch_num == 1 {
+        let crate::executor::BatchedBuild {
+            ixs,
+            priority_fee,
+            needs_continuation,
+            next_fiber_cursor: next_cursor,
+            alts,
+        } = if batch_num == 1 {
             let trigger_retry_deadline =
                 Instant::now() + Duration::from_secs(TRIGGER_RETRY_DEADLINE_SECS);
             loop {
@@ -452,6 +462,7 @@ async fn execute_thread(
         // Submit and confirm
         match submit_and_confirm_batch(
             &final_ixs,
+            &alts,
             executor,
             resources,
             cancelled,
@@ -510,6 +521,7 @@ async fn execute_thread(
 /// Returns Ok(signature) on success, Err((error_msg, attempts)) on failure.
 async fn submit_and_confirm_batch(
     instructions: &[Instruction],
+    alts: &[AddressLookupTableAccount],
     executor: &ExecutorLogic,
     resources: &SharedResources,
     cancelled: &AtomicBool,
@@ -557,9 +569,52 @@ async fn submit_and_confirm_batch(
             }
         };
 
-        // Build and sign transaction
-        let message = Message::new(instructions, Some(&executor.pubkey()));
-        let tx = Transaction::new(&[executor.keypair().as_ref()], message, blockhash);
+        // Build and sign transaction. When the batch carries ALTs, emit a v0
+        // VersionedTransaction so the executor's account-key table is
+        // compressed through the ALT(s). With no ALTs we wrap a legacy
+        // Message in a VersionedTransaction — wire-compatible and lets every
+        // downstream send/sim path stay generic.
+        let signers = [executor.keypair().as_ref()];
+        let tx: VersionedTransaction = if alts.is_empty() {
+            let message = Message::new(instructions, Some(&executor.pubkey()));
+            Transaction::new(&signers, message, blockhash).into()
+        } else {
+            let v0_message =
+                match v0::Message::try_compile(&executor.pubkey(), instructions, alts, blockhash) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        last_error = format!("Failed to compile v0 message: {e}");
+                        log::warn!(
+                            "{}: v0 compile failed (attempt {}): {:?}",
+                            thread_pubkey,
+                            attempt,
+                            e
+                        );
+                        tokio::time::sleep(Duration::from_millis(
+                            BASE_RETRY_DELAY_MS * (1 << attempt.min(4)),
+                        ))
+                        .await;
+                        continue;
+                    }
+                };
+            match VersionedTransaction::try_new(VersionedMessage::V0(v0_message), &signers) {
+                Ok(t) => t,
+                Err(e) => {
+                    last_error = format!("Failed to sign v0 tx: {e}");
+                    log::warn!(
+                        "{}: v0 sign failed (attempt {}): {:?}",
+                        thread_pubkey,
+                        attempt,
+                        e
+                    );
+                    tokio::time::sleep(Duration::from_millis(
+                        BASE_RETRY_DELAY_MS * (1 << attempt.min(4)),
+                    ))
+                    .await;
+                    continue;
+                }
+            }
+        };
 
         // Compute signature before sending (needed for confirmation polling)
         // TPU submission is fire-and-forget so we need the signature upfront

--- a/crates/client/src/executor.rs
+++ b/crates/client/src/executor.rs
@@ -18,11 +18,13 @@ use antegen_thread_program::{
     instruction::ExecThread,
     state::{Signal, Thread, ThreadConfig},
 };
+use indexmap::IndexMap;
+use solana_address_lookup_table_interface::state::AddressLookupTable;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_sdk::{
     account::Account,
     instruction::{AccountMeta, Instruction},
-    message::Message,
+    message::{AddressLookupTableAccount, Message},
     pubkey::Pubkey,
     signature::Keypair,
     signer::Signer,
@@ -37,6 +39,25 @@ use std::sync::Arc;
 
 /// Maximum serialized transaction size in bytes (Solana's PACKET_DATA_SIZE)
 const MAX_TRANSACTION_SIZE: usize = 1232;
+
+/// Max ALTs an ExecThread tx may reference (Solana v0 hard cap).
+const MAX_ALTS_PER_TX: usize = 4;
+
+/// Minimum slot age before an ALT is considered usable. Solana requires the
+/// ALT's most-recent extension to be at least 1 slot in the past before it
+/// can be consumed by a v0 message.
+const MIN_ALT_SLOT_AGE: u64 = 1;
+
+/// Output of a single batching pass. `alts` is empty when no fibers
+/// in the batch carry lookup_tables (or when ALT resolution failed and
+/// we deliberately fell back to the legacy path).
+pub struct BatchedBuild {
+    pub ixs: Vec<Instruction>,
+    pub priority_fee: u64,
+    pub needs_continuation: bool,
+    pub next_fiber_cursor: Option<u8>,
+    pub alts: Vec<AddressLookupTableAccount>,
+}
 
 /// Executor logic for building thread execution transactions
 #[derive(Clone)]
@@ -101,7 +122,7 @@ impl ExecutorLogic {
         thread_pubkey: &Pubkey,
         thread: &Thread,
         override_fiber_cursor: Option<u8>,
-    ) -> Result<(Vec<Instruction>, u64, bool, Option<u8>)> {
+    ) -> Result<BatchedBuild> {
         // Log thread state for debugging
         self.log_thread_debug(thread, thread_pubkey);
 
@@ -110,6 +131,11 @@ impl ExecutorLogic {
         let mut ixs: Vec<Instruction> = Vec::new();
         let mut needs_continuation = false;
         let mut next_fiber_cursor: Option<u8> = None;
+
+        // Stable insertion-ordered union of ALT pubkeys across fibers in
+        // this batch. IndexMap preserves order so the final v0 message
+        // resolution matches the order alts were observed.
+        let mut alt_keys: IndexMap<Pubkey, ()> = IndexMap::new();
 
         // Track fiber_cursor through the chaining loop
         // Signal::Chain tells us to execute next fiber in sequence
@@ -120,7 +146,7 @@ impl ExecutorLogic {
             "{}: starting build: thread.fiber_cursor={}, override={:?}, using={}",
             thread_pubkey, thread.fiber_cursor, override_fiber_cursor, current_fiber_cursor
         );
-        let first_ix = self
+        let first = self
             .build_thread_exec_ix(
                 &mut priority_fee,
                 thread_pubkey,
@@ -130,17 +156,42 @@ impl ExecutorLogic {
             .await?;
 
         // Empty fiber — nothing to submit
-        let Some(first_ix) = first_ix else {
+        let Some((first_ix, first_alts)) = first else {
             info!("{}: first fiber is empty, nothing to submit", thread_pubkey);
-            return Ok((vec![], 0, false, None));
+            return Ok(BatchedBuild {
+                ixs: vec![],
+                priority_fee: 0,
+                needs_continuation: false,
+                next_fiber_cursor: None,
+                alts: vec![],
+            });
         };
 
+        // Seed ALT union with the first fiber's lookup_tables.
+        for lt in &first_alts {
+            alt_keys.insert(*lt, ());
+        }
+        if alt_keys.len() > MAX_ALTS_PER_TX {
+            // Single fiber overflows the v0 cap (rejected at the ix layer
+            // too, but defensive here).
+            return Err(anyhow!(
+                "fiber {} declares {} lookup_tables (max {})",
+                current_fiber_cursor,
+                alt_keys.len(),
+                MAX_ALTS_PER_TX,
+            ));
+        }
+
         debug!(
-            "First instruction built successfully, priority_fee: {}",
-            priority_fee
+            "First instruction built successfully, priority_fee: {}, alts={}",
+            priority_fee,
+            alt_keys.len()
         );
 
-        // Verify single instruction fits in a transaction
+        // Verify single instruction fits in a transaction. We use the
+        // legacy size estimate as a conservative upper bound on the
+        // v0-compressed size; when ALTs are resolved at the end of the
+        // batch the actual tx will be the same or smaller.
         if !self.would_fit_in_transaction(std::slice::from_ref(&first_ix)) {
             return Err(anyhow!(
                 "Single instruction exceeds max transaction size for thread {}",
@@ -179,7 +230,7 @@ impl ExecutorLogic {
                         "Batching: Signal::Chain, adding thread_exec for fiber {}",
                         current_fiber_cursor
                     );
-                    let next_ix = self
+                    let next = self
                         .build_thread_exec_ix(
                             &mut priority_fee,
                             thread_pubkey,
@@ -189,7 +240,7 @@ impl ExecutorLogic {
                         .await?;
 
                     // Empty fiber — stop chaining
-                    let Some(next_ix) = next_ix else {
+                    let Some((next_ix, next_alts)) = next else {
                         info!(
                             "{}: chained fiber {} is empty, stopping chain",
                             thread_pubkey, current_fiber_cursor
@@ -197,16 +248,37 @@ impl ExecutorLogic {
                         break;
                     };
 
-                    // Check if adding this instruction would exceed transaction size
+                    // ALT-count gate (parallel to the byte-size gate).
+                    let mut trial_alts = alt_keys.clone();
+                    for lt in &next_alts {
+                        trial_alts.insert(*lt, ());
+                    }
+                    if trial_alts.len() > MAX_ALTS_PER_TX {
+                        info!(
+                            "{}: ALT cap reached ({} ALTs, adding fiber {} would be {}, max {}), needs continuation",
+                            thread_pubkey,
+                            alt_keys.len(),
+                            current_fiber_cursor,
+                            trial_alts.len(),
+                            MAX_ALTS_PER_TX
+                        );
+                        needs_continuation = true;
+                        next_fiber_cursor = Some(current_fiber_cursor);
+                        break;
+                    }
+
+                    // Byte-size gate. We use the legacy size estimate here as a
+                    // conservative upper bound on the v0-compressed size — when
+                    // ALTs are present the actual tx will be smaller, so we'll
+                    // sometimes split earlier than strictly necessary, but never
+                    // overflow the 1232-byte cap.
                     let mut trial = ixs.clone();
                     trial.push(next_ix.clone());
                     let trial_size = self.estimate_transaction_size_with_budget(&trial);
                     if trial_size <= MAX_TRANSACTION_SIZE {
                         ixs.push(next_ix);
+                        alt_keys = trial_alts;
                     } else {
-                        // Doesn't fit — return what we have and signal continuation.
-                        // The worker will submit this batch, confirm it, re-fetch
-                        // the thread, and call us again for the next batch.
                         let current_size = self.estimate_transaction_size_with_budget(&ixs);
                         info!(
                             "{}: transaction full ({} ix, {} bytes), adding fiber {} would be {} bytes (max {}), needs continuation",
@@ -227,10 +299,11 @@ impl ExecutorLogic {
                     info!("Signal::Close detected - building thread_exec with close_fiber");
                     let close_ix = self.build_close_thread_exec(thread_pubkey, thread).await?;
 
-                    // Check if close instruction fits in current batch
+                    // close_fiber doesn't introduce new ALTs (built from a
+                    // pre-compiled fixed program call), so no ALT-gate check.
                     let mut trial = ixs.clone();
                     trial.push(close_ix.clone());
-                    if self.would_fit_in_transaction(&trial) {
+                    if self.estimate_transaction_size_with_budget(&trial) <= MAX_TRANSACTION_SIZE {
                         ixs.push(close_ix);
                     } else {
                         info!(
@@ -279,15 +352,30 @@ impl ExecutorLogic {
             );
         }
 
+        // Resolve the deduped ALT union to actual on-chain accounts. If any
+        // fetch/decode fails (or any ALT is too young to be usable), the
+        // whole batch falls back to the legacy tx path — simpler than
+        // partial-set logic and matches the size gate's all-or-nothing
+        // semantics.
+        let alts = self.resolve_alts_or_empty(&alt_keys).await;
+
         info!(
-            "{}: built {} instruction(s), priority_fee={}, continuation={}",
+            "{}: built {} instruction(s), priority_fee={}, continuation={}, alts_in_batch={} (resolved={})",
             thread_pubkey,
             ixs.len(),
             priority_fee,
-            needs_continuation
+            needs_continuation,
+            alt_keys.len(),
+            alts.len(),
         );
 
-        Ok((ixs, priority_fee, needs_continuation, next_fiber_cursor))
+        Ok(BatchedBuild {
+            ixs,
+            priority_fee,
+            needs_continuation,
+            next_fiber_cursor,
+            alts,
+        })
     }
 
     /// Fetch thread account from RPC and deserialize.
@@ -369,16 +457,19 @@ impl ExecutorLogic {
         }
     }
 
-    /// Build thread_exec instruction for a specific fiber, returning the instruction.
+    /// Build thread_exec instruction for a specific fiber.
     ///
-    /// Fetches the external fiber account to get compiled instruction and priority fee.
+    /// Returns `Some((ix, lookup_tables))` when the fiber has a non-empty
+    /// compiled_instruction, or `None` when the fiber is empty (e.g. cleared
+    /// after close). `lookup_tables` is the fiber's declared ALT pubkey list
+    /// (always `&[]` for legacy `FiberState`).
     async fn build_thread_exec_ix(
         &self,
         priority_fee: &mut u64,
         thread_pubkey: &Pubkey,
         thread: &Thread,
         fiber_cursor: u8,
-    ) -> Result<Option<Instruction>> {
+    ) -> Result<Option<(Instruction, Vec<Pubkey>)>> {
         debug!("build_thread_exec_ix: fiber_cursor={}", fiber_cursor);
 
         // Fetch the fiber account
@@ -402,7 +493,11 @@ impl ExecutorLogic {
             return Ok(None);
         }
 
-        debug!("Fiber fetched, priority_fee={}", fiber_read.priority_fee());
+        debug!(
+            "Fiber fetched, priority_fee={}, lookup_tables={}",
+            fiber_read.priority_fee(),
+            fiber_read.lookup_tables().len(),
+        );
 
         // Build execute instruction
         let ix = self
@@ -416,7 +511,7 @@ impl ExecutorLogic {
 
         *priority_fee = (*priority_fee).max(fiber_read.priority_fee());
 
-        Ok(Some(ix))
+        Ok(Some((ix, fiber_read.lookup_tables().to_vec())))
     }
 
     /// Build base ThreadExec accounts (shared by build_execute_instruction and build_close_thread_exec)
@@ -848,6 +943,85 @@ impl ExecutorLogic {
         };
 
         Ok((signal, units_consumed))
+    }
+
+    /// Resolve a deduped ALT pubkey union to on-chain `AddressLookupTableAccount`s.
+    ///
+    /// Returns an empty vec on any failure — caller should fall back to the
+    /// legacy `Transaction` path for the whole batch (matches the size gate's
+    /// all-or-nothing semantics).
+    async fn resolve_alts_or_empty(
+        &self,
+        alt_keys: &IndexMap<Pubkey, ()>,
+    ) -> Vec<AddressLookupTableAccount> {
+        if alt_keys.is_empty() {
+            return Vec::new();
+        }
+        let keys: Vec<Pubkey> = alt_keys.keys().copied().collect();
+        match self.fetch_alt_accounts(&keys).await {
+            Ok(alts) => alts,
+            Err(e) => {
+                warn!("ALT resolution failed; falling back to legacy tx: {e}");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Fetch each ALT in `keys` and decode into an `AddressLookupTableAccount`.
+    ///
+    /// All-or-nothing: if any ALT is missing, fails to decode, is deactivated,
+    /// or is younger than [`MIN_ALT_SLOT_AGE`] slots, this returns `Err`.
+    async fn fetch_alt_accounts(&self, keys: &[Pubkey]) -> Result<Vec<AddressLookupTableAccount>> {
+        let (accounts, response_slot) = self
+            .resources
+            .rpc_client
+            .get_multiple_accounts(keys)
+            .await?;
+
+        if accounts.len() != keys.len() {
+            return Err(anyhow!(
+                "ALT fetch returned {} accounts for {} keys",
+                accounts.len(),
+                keys.len()
+            ));
+        }
+
+        let mut out = Vec::with_capacity(keys.len());
+        for (key, maybe_account) in keys.iter().zip(accounts.into_iter()) {
+            let ui_account = maybe_account.ok_or_else(|| anyhow!("ALT {} not found", key))?;
+            let data = decode_account_data(&ui_account.data.0, &ui_account.data.1)
+                .map_err(|e| anyhow!("Failed to decode ALT {} data: {}", key, e))?;
+            let alt = AddressLookupTable::deserialize(&data)
+                .map_err(|e| anyhow!("Failed to deserialize ALT {}: {:?}", key, e))?;
+
+            // Must not be deactivated.
+            if alt.meta.deactivation_slot != u64::MAX {
+                return Err(anyhow!(
+                    "ALT {} is deactivated (deactivation_slot={})",
+                    key,
+                    alt.meta.deactivation_slot
+                ));
+            }
+
+            // Must have aged at least one slot since its last extension to be
+            // usable in a v0 message.
+            let last_extended = alt.meta.last_extended_slot;
+            if last_extended > response_slot.saturating_sub(MIN_ALT_SLOT_AGE) {
+                return Err(anyhow!(
+                    "ALT {} too young (last_extended_slot={}, current_slot={})",
+                    key,
+                    last_extended,
+                    response_slot,
+                ));
+            }
+
+            out.push(AddressLookupTableAccount {
+                key: *key,
+                addresses: alt.addresses.into_owned(),
+            });
+        }
+
+        Ok(out)
     }
 
     /// Fetch fiber account directly from RPC, bypassing cache.

--- a/crates/client/src/rpc/pool.rs
+++ b/crates/client/src/rpc/pool.rs
@@ -148,8 +148,12 @@ impl RpcPool {
         Ok((hash, result.value.last_valid_block_height))
     }
 
-    /// Send a transaction
-    pub async fn send_transaction(&self, transaction: &Transaction) -> Result<Signature> {
+    /// Send a transaction. Generic over `Serialize` so both legacy
+    /// `Transaction` and `VersionedTransaction` can be submitted.
+    pub async fn send_transaction<T: serde::Serialize + ?Sized>(
+        &self,
+        transaction: &T,
+    ) -> Result<Signature> {
         let tx_bytes = bincode::serialize(transaction)?;
         let tx_base64 = BASE64_STANDARD.encode(&tx_bytes);
 
@@ -259,7 +263,7 @@ impl RpcPool {
     pub async fn get_multiple_accounts(
         &self,
         pubkeys: &[Pubkey],
-    ) -> Result<Vec<Option<SafeUiAccount>>> {
+    ) -> Result<(Vec<Option<SafeUiAccount>>, u64)> {
         let addresses: Vec<String> = pubkeys.iter().map(|p| p.to_string()).collect();
 
         let body = json!({
@@ -273,14 +277,23 @@ impl RpcPool {
         });
 
         #[derive(serde::Deserialize)]
+        struct ContextValue {
+            slot: u64,
+        }
+
+        #[derive(serde::Deserialize)]
         struct MultipleAccountsResponse {
+            context: ContextValue,
             value: Vec<Option<SafeUiAccount>>,
         }
 
         let response: JsonRpcResponse<MultipleAccountsResponse> =
             self.execute_with_failover(&body, true).await?;
 
-        Ok(response.result.map(|r| r.value).unwrap_or_default())
+        Ok(response
+            .result
+            .map(|r| (r.value, r.context.slot))
+            .unwrap_or_default())
     }
 
     /// Get program accounts with optional filters
@@ -323,9 +336,9 @@ impl RpcPool {
     }
 
     /// Simulate a transaction and return accounts
-    pub async fn simulate_transaction(
+    pub async fn simulate_transaction<T: serde::Serialize + ?Sized>(
         &self,
-        transaction: &Transaction,
+        transaction: &T,
         account_addresses: &[Pubkey],
     ) -> Result<SafeSimulationResult> {
         let tx_bytes = bincode::serialize(transaction)?;

--- a/crates/client/src/tpu/mod.rs
+++ b/crates/client/src/tpu/mod.rs
@@ -34,7 +34,6 @@
 
 use anyhow::{anyhow, Result};
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::transaction::Transaction;
 use solana_tpu_client_next::{
     connection_workers_scheduler::{
         BindTarget, ConnectionWorkersScheduler, ConnectionWorkersSchedulerConfig, Fanout,
@@ -173,7 +172,10 @@ impl TpuClient {
     /// Returns an error if:
     /// - Transaction serialization fails
     /// - The internal channel is closed (scheduler has stopped)
-    pub async fn send_transaction(&self, transaction: &Transaction) -> Result<()> {
+    pub async fn send_transaction<T: serde::Serialize + ?Sized>(
+        &self,
+        transaction: &T,
+    ) -> Result<()> {
         let wire_tx = bincode::serialize(transaction)?;
         let batch = TransactionBatch::new(vec![wire_tx]);
 


### PR DESCRIPTION
## Summary

Switches the executor's transaction path to a v0 build that consumes the deduped+truncated union of Address Lookup Tables declared by the fibers in a single `ExecThread` batch. Builds the second half of the ALT-support work — PR 1 (#32) added `FiberVersionedState.lookup_tables` and the read-side dispatcher; this PR makes the executor actually compress batched-fiber txs through those ALTs.

**Motivation:** downstream consumers (e.g. srsly) currently hit the 1232-byte tx-size limit batching back-to-back fibers. With ~10 static addresses in an ALT, each batched `ExecThread` tx drops ~310 bytes — enough to land both fibers in one tx instead of paying a continuation round-trip.

## What changes

- **`BatchedBuild`** (new struct) replaces the 4-tuple return from `build_execute_transaction`. Carries an `alts: Vec<AddressLookupTableAccount>` field the worker threads into the tx-build path.
- **ALT-count gate** parallel to the existing 1232-byte size gate: walks fibers in iteration order, trial-then-commits each fiber's `lookup_tables` into an `IndexMap` union. Exceeding 4 distinct ALTs triggers `needs_continuation = true` with the offending fiber's cursor — same continuation semantics as the size gate.
- **`fetch_alt_accounts`** (new helper) fetches each ALT via `RpcPool::get_multiple_accounts`, decodes via `AddressLookupTable::deserialize`, checks the ALT is not deactivated, and rejects ALTs younger than 1 slot. All-or-nothing: any failure drops the whole batch to the legacy `Transaction` path.
- **`RpcPool::get_multiple_accounts`** now returns `(accounts, context_slot)` so the ALT freshness check has a reference slot without a second RPC call.
- **Worker (`submit_and_confirm_batch`)** builds a `VersionedTransaction` always: legacy `Message` wrapped when `alts` is empty, `v0::Message` via `try_compile` when non-empty. Wire format is identical for the legacy case, so downstream send paths stay one code path.
- **Generic send/simulate helpers:** `RpcPool::send_transaction` / `RpcPool::simulate_transaction` / `TpuClient::send_transaction` are generic over `Serialize`, so they accept both `Transaction` and `VersionedTransaction` with no signature break for existing callers.

## Design tradeoffs

**Size gate stays on the legacy estimator during batching.** It's a conservative upper bound on the v0-compressed size — when ALTs are present the actual wire tx is the same or smaller than the estimate, so we never overflow. We may under-pack slightly when ALT compression would have left room for an additional fiber. Tightening this to a v0-aware estimator is a follow-up; it would require fetching ALTs during batching rather than at the end.

**Simulation also stays on the legacy message format.** The Signal we extract from simulation is encoding-independent, and simulating with a legacy message avoids paying the ALT-fetch cost per Chain step.

**Fallback semantics:** if `fetch_alt_accounts` fails for any reason (missing, deactivated, too young, decode error), `resolve_alts_or_empty` swallows the error and returns `Vec::new()`. The worker then takes the legacy path for the batch, preserving exactly the pre-PR behavior. No silent failures — the swallowed error is logged at `warn!`.

## Breaking changes

- `build_execute_transaction` return type changes from `(Vec<Instruction>, u64, bool, Option<u8>)` to `BatchedBuild`. Only internal callers in `antegen-client` itself; downstream consumers of the `antegen-client` crate that called this directly will need to destructure the struct.
- `RpcPool::get_multiple_accounts` return type adds the context slot. Same crate-internal scope.

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo clippy --workspace --lib --bins -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo test --workspace --lib` — existing tests pass.
- [x] `./target/debug/antegen --version` smoke.
- [ ] **CI green** (anchor build + `cargo test --workspace --locked` + mainnet build).
- [ ] **End-to-end ALT scenario.** Requires `solana-test-validator` + scripted multi-fiber thread with a populated ALT; out of scope for this PR. Belongs in an integration harness alongside any future srsly-driven scenario. Will validate: a thread that previously triggered `continuation = true` for back-to-back fibers should land both in one v0 tx, with the "transaction full (...)" log line absent.

## Follow-ups (not in this PR)

- v0-aware size estimator that uses the resolved ALT addresses to compute compressed indices during batching. Wins back the under-packed cases.
- ALT contents cache so consecutive batches reuse a single ALT fetch.
- End-to-end ALT integration test on `solana-test-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)